### PR TITLE
Basic io.write_nrrd implementation

### DIFF
--- a/navis/io/__init__.py
+++ b/navis/io/__init__.py
@@ -13,14 +13,14 @@
 
 from .json_io import write_json, read_json
 from .swc_io import read_swc, write_swc
-from .nrrd_io import read_nrrd
+from .nrrd_io import read_nrrd, write_nrrd
 from .precomputed_io import write_precomputed, read_precomputed
 from .hdf_io import read_h5, write_h5, inspect_h5
 from .rda_io import read_rda
 
 __all__ = ['write_json', 'read_json',
            'read_swc', 'write_swc',
-           'read_nrrd',
+           'read_nrrd', 'write_nrrd',
            'read_h5', 'write_h5', 'inspect_h5',
            'write_precomputed', 'read_precomputed',
            'read_rda']

--- a/navis/io/nrrd_io.py
+++ b/navis/io/nrrd_io.py
@@ -20,7 +20,7 @@ from glob import glob
 
 import multiprocessing as mp
 
-from typing import Union, Iterable, Optional
+from typing import Union, Iterable, Optional, Dict, Any
 from typing_extensions import Literal
 
 from .. import config, utils, core
@@ -202,6 +202,22 @@ def read_nrrd(f: Union[str, Iterable],
     x.nrrd_header = header
 
     return x
+
+
+def write_nrrd(
+    f: Union[str, os.PathLike],
+    neuron: 'core.VoxelNeuron',
+    attrs: Optional[Dict[str, Any]] = None,
+):
+    header = getattr(neuron, "nrrd_header", {})
+
+    quant = neuron.units_xyz
+    header["space units"] = [str(quant.units)] * len(quant)
+    header["space directions"] = np.diag(quant.magnitude).tolist()
+
+    header.update(attrs or {})
+
+    nrrd.write(os.fspath(f), neuron._data, header)
 
 
 def _worker_wrapper(kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+import os
 
 import pandas as pd
 import pytest
+import numpy as np
+import nrrd
 
 import navis
 
@@ -52,3 +55,22 @@ def swc_source_multi(request, data_dir: Path):
         yield [dpath, fpath]
     else:
         raise ValueError(f"Unknown parameter '{request.param}'")
+
+
+@pytest.fixture
+def voxel_nrrd_path(tmp_path):
+    parent = tmp_path / "nrrd"
+    parent.mkdir()
+    path = parent / "simple.nrrd"
+    data = np.zeros((15, 15, 15))
+    rng = np.random.RandomState(1991)
+    core = rng.random((5, 5, 15))
+    data[5:10, 5:10, :] = core
+
+    header = {
+        "space directions": np.diag([1, 2, 3]).tolist(),
+        "space units": ["um", "um", "um"],
+    }
+    nrrd.write(os.fspath(path), data, header)
+
+    return path

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import navis
 import pytest
 import tempfile
+import numpy as np
 
 from pathlib import Path
 
@@ -72,3 +73,17 @@ def test_precomputed_mesh_io(filename):
 
         # Assert that we loaded the same number of neurons
         assert len(n) == len(n2)
+
+
+def test_read_nrrd(voxel_nrrd_path):
+    navis.read_nrrd(voxel_nrrd_path, output="voxels", errors="raise")
+
+
+def test_roundtrip_nrrd(voxel_nrrd_path):
+    vneuron = navis.read_nrrd(voxel_nrrd_path, output="voxels", errors="raise")
+    outpath = voxel_nrrd_path.parent / "written.nrrd"
+    navis.write_nrrd(voxel_nrrd_path.parent / "written.nrrd", vneuron)
+    vneuron2 = navis.read_nrrd(outpath, output="voxels", errors="raise")
+    assert np.allclose(vneuron._data, vneuron2._data)
+    assert np.allclose(vneuron.units_xyz.magnitude, vneuron2.units_xyz.magnitude)
+    assert vneuron.units_xyz.units == vneuron2.units_xyz.units


### PR DESCRIPTION
For VoxelNeurons.
Adds (stupid) test for reading and for round trip read-write-read.

Does this look like a worthwhile MVP for a writer here? Writing NRRD is one of the things CATMAID uses natverse for.