### PR TITLE
Fix ncollpyde in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#supported-settings
+
+version: 2
+
+sphinx:
+  builder: html
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+    rust: "1.55"
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,5 +13,6 @@ build:
 
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,5 @@ sphinx-autodoc-typehints
 sphinx-copybutton
 neuprint-python
 wheel>=0.35.1
-# ncollpyde 0.15 currently acts up on readthedocs
-ncollpyde~=0.14.0
 # Optional dependency - required for plot_flat
 pygraphviz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=3.1
 matplotlib>=3.2
 morphops>=0.1.11
-ncollpyde>=0.11
+ncollpyde>=0.18
 networkx>=2.4
 numpy>=1.16
 pandas>=1.0


### PR DESCRIPTION
This config should get RTD to install a rust compiler, which will allow ncollpyde to build from source if a wheel isn't available. Thanks to @messense for documenting this in maturin and contributing the config to ncollpyde itself!

Probably want to make sure this gets through the RTD sausage machine, does that happen for PRs? Looks like it needs to be enabled here https://docs.readthedocs.io/en/stable/pull-requests.html