### PR TITLE
Add {read,write}_h5 to API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -500,6 +500,8 @@ Functions to import/export neurons.
     navis.write_json
     navis.write_precomputed
     navis.read_precomputed
+    navis.read_h5
+    navis.write_h5
 
 .. _api_interfaces:
 


### PR DESCRIPTION
If these functions are ready for prime time it'd be great to have them on the docs site!