### PR TITLE
Fix deepcopy(my_base_neuron)

### DIFF
--- a/navis/core/base.py
+++ b/navis/core/base.py
@@ -165,8 +165,10 @@ class BaseNeuron:
     def __copy__(self):
         return self.copy(deepcopy=False)
 
-    def __deepcopy__(self):
-        return self.copy(deepcopy=True)
+    def __deepcopy__(self, memo):
+        result = self.copy(deepcopy=True)
+        memo[id(self)] = result
+        return result
 
     def __eq__(self, other):
         """Implement neuron comparison."""
@@ -579,14 +581,15 @@ class BaseNeuron:
         if not inplace:
             return n
 
-    def copy(self) -> 'BaseNeuron':
+    def copy(self, deepcopy=False) -> 'BaseNeuron':
         """Return a copy of the neuron."""
+        copy_fn = copy.deepcopy if deepcopy else copy.copy
         # Attributes not to copy
         no_copy = ['_lock']
         # Generate new empty neuron
         x = self.__class__()
         # Override with this neuron's data
-        x.__dict__.update({k: copy.copy(v) for k, v in self.__dict__.items() if k not in no_copy})
+        x.__dict__.update({k: copy_fn(v) for k, v in self.__dict__.items() if k not in no_copy})
 
         return x
 

--- a/tests/test_neurons.py
+++ b/tests/test_neurons.py
@@ -1,8 +1,15 @@
+from copy import deepcopy
+
 import navis
 
 import pytest
 
 from .common import with_igraph
+
+
+def test_deepcopy():
+    nrn = navis.core.BaseNeuron()
+    deepcopy(nrn)
 
 
 def test_from_swc(swc_source):


### PR DESCRIPTION
`__deepcopy__` needed another argument, useful for recursive copies.
Added a test which failed before and now passes.
BaseNeuron.copy() also didn't have the deepcopy kwarg, now added and
made to do something.

Noticed by @swilson27.

As an afterthought, currently `.copy(deepcopy=False)` isn't quite as shallow as it could be, as each of the attributes are shallow copied rather than just added to the new object. I doubt it'll ever come up and it's probably safer to leave it as it is.