### PR TITLE
Fix to prevent rounding with fraction voxels

### DIFF
--- a/navis/conversion/converters.py
+++ b/navis/conversion/converters.py
@@ -325,8 +325,8 @@ def neuron2voxels(x: 'core.BaseNeuron',
         bounds = bounds.T
 
     # Shape of grid
-    dim = np.ceil(bounds[:, 1]) - np.floor(bounds[:, 0])
-    shape = np.ceil(dim / pitch).astype(int) + 1
+    dim = np.ceil(bounds[:, 1] / pitch) - np.floor(bounds[:, 0] / pitch)
+    shape = np.ceil(dim).astype(int) + 1
 
     # Get unique voxels
     if not counts:


### PR DESCRIPTION
```vx = navis.voxelize(cs, pitch='0.4 microns', smooth=1, counts=True, bounds=np.array([[0.0,0.0,0.0],[263.6,515.6,152.4]]))```
Trying to match template space 264x516 microns (660x1290) 382 z slices
so need to take away 0.4 to allow for the 0 index but the rounding is taking me over so adding extra rows
So I suggest the /pitch first before rounding 