### PR TITLE
Update meshing.py

### DIFF
--- a/navis/conversion/meshing.py
+++ b/navis/conversion/meshing.py
@@ -159,10 +159,8 @@ def _mesh_from_voxels_single(voxels, spacing=(1, 1, 1), step_size=1):
     mat, offset = _voxels_to_matrix(voxels, pad=1)
 
     # Use marching cubes to create surface model
-    # (newer versions of skimage have a "marching cubes" function and
-    # the marching_cubes_lewiner is deprecreated)
     marching_cubes = getattr(measure, 'marching_cubes',
-                             getattr(measure, 'marching_cubes_lewiner', None))
+                             getattr(measure, 'marching_cubes', None))
     verts, faces, normals, values = marching_cubes(mat,
                                                    level=.5,
                                                    step_size=step_size,


### PR DESCRIPTION
I had to change marching_cubes_lewiner to marching_cubes in order to get this example to work: 

# Start with a mesh neuron
m = navis.example_neurons(1, kind='mesh')

# Skeletonize the mesh
s = navis.skeletonize(m)

# Make dotprops (this works from any other neuron type
dp = navis.make_dotprops(s, k=5)

# Voxelize the mesh
vx = navis.voxelize(m, pitch='2 microns', smooth=1, counts=True)

# Mesh the voxels
mm = navis.mesh(vx.threshold(.5))  # where things broke

# Co-visualize the mesh and the skeleton
fig = navis.plot3d([m, s], color=[(1, 1, 1, .2), 'r'])

Don't know if this would be helpful to anyone else...