### PR TITLE
[WIP] Shared memory for NBLAST

### DIFF
--- a/navis/nbl/base.py
+++ b/navis/nbl/base.py
@@ -61,15 +61,7 @@ class Blaster(ABC):
 
     @dtype.setter
     def dtype(self, dtype):
-        try:
-            self._dtype = np.dtype(dtype)
-        except TypeError:
-            try:
-                self._dtype = FLOAT_DTYPES[dtype]
-            except KeyError:
-                raise ValueError(
-                    f'Unknown precision/dtype {dtype}. Expected on of the following: 16, 32 or 64 (default)'
-                )
+        self._dtype = parse_precision(dtype)
 
     def pair_query_target(self, pairs, scores='forward'):
         """BLAST multiple pairs.
@@ -263,3 +255,15 @@ def create_shared_array(shape, dtype):
     arr = np.ndarray(shape, dtype=dtype, buffer=shm.buf)
 
     return shm, arr
+
+
+def parse_precision(dtype):
+    """Parse precision into numpy dtype."""
+    try:
+        return np.dtype(dtype)
+    except TypeError:
+        try:
+            return FLOAT_DTYPES[dtype]
+        except KeyError:
+            raise ValueError(f'Unknown precision/dtype {dtype}. Expected one '
+                             'of the following: 16, 32 or 64 (default)')


### PR DESCRIPTION
With larger NBLASTs, memory consumption becomes an issue. During the NBLAST each child process holds only the scores it works on in memory. On completion, however, that data has to be sent to the parent process which takes time and causes a memory spike (I'm pretty sure it makes a copy). Subsequently, we need to stitch the scores into one big matrix which again takes time and memory.

This PR is work in progress but the basic idea is this:
1. Use `multiprocessing.shared_memory.SharedMemory` to reserve some memory 
2. The parent process wraps that reserved memory buffer as numpy array
3. Each NBLASTing child process is given a reference to the memory buffer and writes the scores it works on to that buffer. Because the writes are non-overlapping, we don't have to bother with a queue.

#### Advantages:
- no data sent back from the child processes 
- scores only ever exist once 
- no annoying post-NBLAST stitching required (this will also be super useful for `nblast_smart`)

#### Disadvantages:
The memory management is a bit more annoying because unlike your run-of-the-mill numpy array the `SharedMemory` needs to be explicitly released by calling `SharedMemory.close()`. If one doesn't do this before exiting the session, there is a `UserWarning`. For now I solved this by hooking into `atexit` but I'm pretty sure that if the user simply deletes the array/dataframe (i.e. something like `del scores`) the memory is not freed. That bit needs a bit of exploration - perhaps we can implement some custom `__del__` method or something.

I have so far only implemented this for `navis.nblast` - all other functions in this branch still use the old approach. Some quick and dirty benchmarks show some decent speed up, in particular for large NBLASTs. Haven't done proper memory profiling yet.

@clbarnes any thoughts on this? In particular on the somewhat opaque issue with memory not being freed.

Code reviews welcome (the whole NBLAST module is becoming fairly complex)!