### PR TITLE
Fix bug in plotting/plotly/graph_objs.py

### DIFF
--- a/navis/plotting/plotly/graph_objs.py
+++ b/navis/plotting/plotly/graph_objs.py
@@ -456,7 +456,7 @@ def scatter2plotly(x, **kwargs):
         if isinstance(scatter, pd.DataFrame):
             if not all([c in scatter.columns for c in ['x', 'y', 'z']]):
                 raise ValueError('DataFrame must have x, y and z columns')
-            scatter = [['x', 'y', 'z']].values
+            scatter = scatter[['x', 'y', 'z']].values
 
         if not isinstance(scatter, np.ndarray):
             scatter = np.array(scatter)


### PR DESCRIPTION
Dear navis-org

I think I found a bug while playing around with `scatter2plotly`. If I pass a list of `pd.DataFrame` as input, the function fails in the line I corrected, because I think this line is intended to get the x,y,z coordinates of the dataframe, but it forgets to refer to it, which means that to work with it now, users need to pass lists of np.arrays with just these 3 columns
