### PR TITLE
Miscellaneous hackathon fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Schneider-Mizell CM, Gerhard S, Longair M, Kazimiers T, Li, Feng L, Zwart M … 
 1. Fork this repository
 2. `git clone` it to your local machine
 3. Install the full development dependencies with `pip install -r requirements.txt`
-4. Install the package in editable mode with `pip install -e .[all]`
+4. Install the package in editable mode with `pip install -e ".[all]"`
 5. Create, `git add`, `git commit`, `git push`, and pull request your changes.
 
 Run the tests locally with `pytest -v`.

--- a/navis/nbl/smat.py
+++ b/navis/nbl/smat.py
@@ -32,6 +32,7 @@ import numpy as np
 import pandas as pd
 
 from .. import config
+from ..core import Dotprops
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,7 @@ class LookupNdBuilder:
         self.bin_method = method
         return self
 
-    def _object_keys(self) -> Sequence[DotpropKey]:
+    def _object_keys(self) -> Sequence[NeuronKey]:
         """Get all indices into objects instance member."""
         try:
             return self.objects.keys()
@@ -237,28 +238,28 @@ class LookupNdBuilder:
             return range(len(self.objects))
 
     @property
-    def nonmatching(self) -> List[DotpropKey]:
+    def nonmatching(self) -> List[NeuronKey]:
         """Indices of nonmatching set of neurons."""
         if self._nonmatching_list is None:
             return list(self._object_keys())
         return self._nonmatching_list
 
-    def _yield_matching_pairs(self) -> Iterator[Tuple[DotpropKey, DotpropKey]]:
+    def _yield_matching_pairs(self) -> Iterator[Tuple[NeuronKey, NeuronKey]]:
         """Yield all index pairs within all matching pairs."""
         for ms in self.matching_lists:
             yield from yield_not_same(permutations(ms, 2))
 
-    def _yield_nonmatching_pairs(self) -> Iterator[Tuple[DotpropKey, DotpropKey]]:
+    def _yield_nonmatching_pairs(self) -> Iterator[Tuple[NeuronKey, NeuronKey]]:
         """Yield all index pairs within all non-matching pairs."""
         if self._nonmatching_list is None:
             raise ValueError('Must provide non-matching pairs explicitly.')
         yield from yield_not_same(permutations(self._nonmatching_list, 2))
 
-    def _yield_nonmatching_pairs_greedy(self, rng=None) -> Iterator[Tuple[DotpropKey, DotpropKey]]:
+    def _yield_nonmatching_pairs_greedy(self, rng=None) -> Iterator[Tuple[NeuronKey, NeuronKey]]:
         """Yield all index pairs within nonmatching list."""
         return yield_not_same(permutations(self.nonmatching, 2))
 
-    def _yield_nonmatching_pairs_batched(self) -> Iterator[Tuple[DotpropKey, DotpropKey]]:
+    def _yield_nonmatching_pairs_batched(self) -> Iterator[Tuple[NeuronKey, NeuronKey]]:
         """Yield all index pairs within nonmatching list.
 
         This function tries to generate truely random draws of all possible
@@ -566,9 +567,9 @@ def dist_dot_alpha(q: Dotprops, t: Dotprops):
 class LookupDistDotBuilder(LookupNdBuilder):
     def __init__(
         self,
-        dotprops: Union[List[Dotprops], Mapping[DotpropKey, Dotprops]],
-        matching_lists: List[List[DotpropKey]],
-        nonmatching_list: Optional[List[DotpropKey]] = None,
+        dotprops: Union[List[Dotprops], Mapping[NeuronKey, Dotprops]],
+        matching_lists: List[List[NeuronKey]],
+        nonmatching_list: Optional[List[NeuronKey]] = None,
         use_alpha: bool = False,
         draw_strat: str = 'batched',
         seed: int = DEFAULT_SEED,
@@ -642,9 +643,6 @@ def parse_boundary(item: str):
             f"Enclosing characters '{explicit_interval}' do not match a half-open interval"
         )
     return tuple(float(i) for i in item[1:-1].split(",")), right
-
-
-T = TypeVar("T")
 
 
 class LookupAxis(ABC, Generic[T]):

--- a/navis/nbl/smat.py
+++ b/navis/nbl/smat.py
@@ -252,8 +252,7 @@ class LookupNdBuilder:
         """Yield all index pairs within all non-matching pairs."""
         if self._nonmatching_list is None:
             raise ValueError('Must provide non-matching pairs explicitly.')
-        for ms in self._nonmatching_list:
-            yield from yield_not_same(permutations(ms, 2))
+        yield from yield_not_same(permutations(self._nonmatching_list, 2))
 
     def _yield_nonmatching_pairs_greedy(self, rng=None) -> Iterator[Tuple[DotpropKey, DotpropKey]]:
         """Yield all index pairs within nonmatching list."""

--- a/navis/plotting/k3d/conftest.py
+++ b/navis/plotting/k3d/conftest.py
@@ -1,0 +1,10 @@
+"""Configuration for submodule doctests.
+
+Should be importable (but not useful)
+without development dependencies.
+"""
+try:
+    import k3d
+
+except ImportError:
+    collect_ignore_glob = ["*.py"]


### PR DESCRIPTION
This fixes a few failing tests, some of the louder typechecking noise in my env, and aims to make get a dev env setup a bit smoother.

- README: adapt dev instructions for zsh-like shells
- pytest: ignore submodule on missing k3d dep
- smat: fix non-match iterations
- smat: replace with valid type hint
- Add minimal editorconfig
