### PR TITLE
Use conventional logger names when NAVIS_SKIP_LOG_SETUP

### DIFF
--- a/navis/config.py
+++ b/navis/config.py
@@ -53,6 +53,13 @@ skip_log_setup = os.environ.get('NAVIS_SKIP_LOG_SETUP', '').lower() == 'true'
 if not skip_log_setup:
     default_logging()
 
+
+def get_logger(name: str):
+    if skip_log_setup:
+        return logging.getLogger(name)
+    return logger
+
+
 # Default settings for progress bars
 pbar_hide = False
 pbar_leave = False

--- a/navis/connectivity/matrix_utils.py
+++ b/navis/connectivity/matrix_utils.py
@@ -23,7 +23,7 @@ from typing import Union, Optional
 from .. import utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def group_matrix(mat: Union[pd.DataFrame, np.ndarray],

--- a/navis/connectivity/predict.py
+++ b/navis/connectivity/predict.py
@@ -24,7 +24,7 @@ from ..core import TreeNeuron, NeuronList
 from .. import config, graph
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 NeuronObject = Union[TreeNeuron, NeuronList]
 

--- a/navis/connectivity/similarity.py
+++ b/navis/connectivity/similarity.py
@@ -28,7 +28,7 @@ from concurrent.futures import ProcessPoolExecutor
 from .. import config, core, utils
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 __all__ = sorted(['connectivity_similarity',  'synapse_similarity'])

--- a/navis/conversion/converters.py
+++ b/navis/conversion/converters.py
@@ -21,7 +21,7 @@ from typing import Union, Optional
 
 from .. import core, config, utils, morpho, graph
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 @utils.map_neuronlist(desc='Skeletonizing', allow_parallel=True)

--- a/navis/conversion/meshing.py
+++ b/navis/conversion/meshing.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     skimage = None
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def voxels2mesh(vox: Union['core.VoxelNeuron', np.ndarray],

--- a/navis/conversion/wrappers.py
+++ b/navis/conversion/wrappers.py
@@ -21,7 +21,7 @@ from .. import core, config, utils
 from .converters import neuron2voxels, mesh2skeleton, tree2meshneuron
 from .meshing import voxels2mesh
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 @utils.map_neuronlist(desc='Skeletonizing', allow_parallel=True)

--- a/navis/core/base.py
+++ b/navis/core/base.py
@@ -37,7 +37,7 @@ except ImportError:
 __all__ = ['Neuron']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # This is to prevent pint to throw a warning about numpy integration
 with warnings.catch_warnings():

--- a/navis/core/core_utils.py
+++ b/navis/core/core_utils.py
@@ -39,7 +39,7 @@ except ImportError:
 __all__ = ['make_dotprops', 'to_neuron_space']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def temp_property(func):

--- a/navis/core/dotprop.py
+++ b/navis/core/dotprop.py
@@ -41,7 +41,7 @@ except ImportError:
 __all__ = ['Dotprops']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # This is to prevent pint to throw a warning about numpy integration
 with warnings.catch_warnings():

--- a/navis/core/mesh.py
+++ b/navis/core/mesh.py
@@ -43,7 +43,7 @@ except ImportError:
 __all__ = ['MeshNeuron']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # This is to prevent pint to throw a warning about numpy integration
 with warnings.catch_warnings():

--- a/navis/core/neuronlist.py
+++ b/navis/core/neuronlist.py
@@ -31,7 +31,7 @@ from .. import utils, config, core
 __all__ = ['NeuronList']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 class NeuronList:

--- a/navis/core/skeleton.py
+++ b/navis/core/skeleton.py
@@ -42,7 +42,7 @@ except ImportError:
 __all__ = ['TreeNeuron']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # This is to prevent pint to throw a warning about numpy integration
 with warnings.catch_warnings():

--- a/navis/core/volumes.py
+++ b/navis/core/volumes.py
@@ -29,7 +29,7 @@ from typing_extensions import Literal
 from .. import utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 class Volume(trimesh.Trimesh):

--- a/navis/core/voxel.py
+++ b/navis/core/voxel.py
@@ -34,7 +34,7 @@ except ImportError:
 __all__ = ['VoxelNeuron']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # This is to prevent pint to throw a warning about numpy integration
 with warnings.catch_warnings():

--- a/navis/graph/converters.py
+++ b/navis/graph/converters.py
@@ -27,7 +27,7 @@ except ImportError:
 from .. import config, core
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['network2nx', 'network2igraph', 'neuron2igraph', 'nx2neuron',
                   'neuron2nx', 'neuron2KDTree', 'neuron2tangents'])

--- a/navis/graph/graph_utils.py
+++ b/navis/graph/graph_utils.py
@@ -27,7 +27,7 @@ from scipy.sparse import csgraph, csr_matrix
 from .. import graph, utils, config, core, morpho
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['classify_nodes', 'cut_skeleton', 'longest_neurite',
                   'split_into_fragments', 'reroot_skeleton', 'distal_to',

--- a/navis/interfaces/allen_celltypes.py
+++ b/navis/interfaces/allen_celltypes.py
@@ -35,7 +35,7 @@ import pandas as pd
 from .. import config, utils
 from ..core import TreeNeuron, NeuronList
 
-logger = config.logger
+logger = config.get_logger(__name__)
 dataset = None
 
 DTYPES = {

--- a/navis/interfaces/blender.py
+++ b/navis/interfaces/blender.py
@@ -34,7 +34,7 @@ import trimesh as tm
 from .. import core, utils, config
 from ..plotting.colors import eval_color
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 try:
     import bpy

--- a/navis/interfaces/insectbrain_db.py
+++ b/navis/interfaces/insectbrain_db.py
@@ -36,7 +36,7 @@ from .. import config
 from ..core import Volume, TreeNeuron, NeuronList
 from ..utils import make_url, make_iterable
 
-logger = config.logger
+logger = config.get_logger(__name__)
 baseurl = 'https://www.insectbraindb.org'
 
 

--- a/navis/interfaces/microns.py
+++ b/navis/interfaces/microns.py
@@ -41,7 +41,7 @@ except BaseException:
     raise
 
 
-logger = config.logger
+logger = config.get_logger(__name__)
 dataset = None
 
 CAVE_DATASTACKS = {

--- a/navis/interfaces/neuprint.py
+++ b/navis/interfaces/neuprint.py
@@ -50,7 +50,7 @@ from ..core import Volume, TreeNeuron, MeshNeuron, NeuronList
 from ..graph import neuron2KDTree
 from ..morpho import subset_neuron
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # Define some integer types
 int_types = (int, np.int32, np.int64, np.int, np.int0)

--- a/navis/interfaces/neuron/comp.py
+++ b/navis/interfaces/neuron/comp.py
@@ -106,7 +106,7 @@ from neuron.units import ms, mV
 neuron.h.load_file('stdrun.hoc')
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = []
 

--- a/navis/interfaces/neuron/network.py
+++ b/navis/interfaces/neuron/network.py
@@ -38,7 +38,7 @@ from neuron.units import ms, mV
 neuron.h.load_file('stdrun.hoc')
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = []
 

--- a/navis/interfaces/r.py
+++ b/navis/interfaces/r.py
@@ -45,7 +45,7 @@ if rpy2_major_version >= 3:
 
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def try_importr(x):

--- a/navis/interfaces/vfb.py
+++ b/navis/interfaces/vfb.py
@@ -39,7 +39,7 @@ from io import StringIO
 
 from .. import config, utils, core
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 # For convenience some shorthands for datasets

--- a/navis/intersection/intersect.py
+++ b/navis/intersection/intersect.py
@@ -25,7 +25,7 @@ from .ray import *
 from .convex import *
 
 # Set up logging -> has to be before try statement!
-logger = config.logger
+logger = config.get_logger(__name__)
 
 try:
     from pyoctree import pyoctree

--- a/navis/io/base.py
+++ b/navis/io/base.py
@@ -41,7 +41,7 @@ except ImportError:
 __all__ = ["BaseReader"]
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 DEFAULT_INCLUDE_SUBDIRS = False
 

--- a/navis/io/json_io.py
+++ b/navis/io/json_io.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from .. import config, core
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 __all__ = ['write_json', 'read_json']

--- a/navis/io/mesh_io.py
+++ b/navis/io/mesh_io.py
@@ -24,7 +24,7 @@ from .. import config, utils, core
 from . import base
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def read_mesh(f: Union[str, Iterable],

--- a/navis/io/nmx_io.py
+++ b/navis/io/nmx_io.py
@@ -27,7 +27,7 @@ from . import base
 __all__ = ["read_nmx"]
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 NODE_COLUMNS = ('node_id', 'label', 'x', 'y', 'z', 'radius', 'parent_id')
 DEFAULT_PRECISION = 32

--- a/navis/io/nrrd_io.py
+++ b/navis/io/nrrd_io.py
@@ -26,7 +26,7 @@ from .. import config, utils, core
 from . import base
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def write_nrrd(x: 'core.NeuronObject',

--- a/navis/io/rda_io.py
+++ b/navis/io/rda_io.py
@@ -26,7 +26,7 @@ from .. import config, utils, core
 __all__ = ['read_rda']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def read_rda(f: str,

--- a/navis/io/swc_io.py
+++ b/navis/io/swc_io.py
@@ -36,7 +36,7 @@ except ImportError:
 __all__ = ["SwcReader", "read_swc", "write_swc"]
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 NODE_COLUMNS = ('node_id', 'label', 'x', 'y', 'z', 'radius', 'parent_id')
 COMMENT = "#"

--- a/navis/matching/bipartite.py
+++ b/navis/matching/bipartite.py
@@ -20,6 +20,8 @@ from typing import Optional
 
 from .. import utils, config
 
+logger = config.get_logger(__name__)
+
 
 def bipartite_match(scores: pd.DataFrame,
                     one_to_one: bool = True,
@@ -234,7 +236,7 @@ def bipartite_match(scores: pd.DataFrame,
     V_miss['score'] = None
 
     if not U_miss.empty or not V_miss.empty:
-        config.logger.info(f'{U_miss.shape[0] + V_miss.shape[0]} neurons could '
+        logger.info(f'{U_miss.shape[0] + V_miss.shape[0]} neurons could '
                            'not be matched under the given constraints.')
 
     return pd.concat([matches, U_miss, V_miss], axis=0).reset_index(drop=True)

--- a/navis/meshes/mesh_utils.py
+++ b/navis/meshes/mesh_utils.py
@@ -32,7 +32,7 @@ except ImportError:
 from .. import core, config, intersection, graph, morpho
 
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def fix_mesh(mesh: Union[tm.Trimesh, 'core.MeshNeuron'],

--- a/navis/models/network_models.py
+++ b/navis/models/network_models.py
@@ -22,7 +22,7 @@ from typing import Iterable, Union, Optional, Callable
 from .. import config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['BayesianTraversalModel', 'TraversalModel', 'linear_activation_p', 'random_linear_activation_function']
 

--- a/navis/morpho/analyze.py
+++ b/navis/morpho/analyze.py
@@ -21,7 +21,7 @@ from .. import config, core
 from typing import Sequence
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")

--- a/navis/morpho/fq.py
+++ b/navis/morpho/fq.py
@@ -28,7 +28,7 @@ from typing_extensions import Literal
 from .. import config, core, utils
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['form_factor'])
 

--- a/navis/morpho/manipulation.py
+++ b/navis/morpho/manipulation.py
@@ -32,7 +32,7 @@ from .. import graph, utils, config, core
 from . import mmetrics, subset
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['prune_by_strahler', 'stitch_skeletons', 'split_axon_dendrite',
                   'average_skeletons', 'despike_skeleton', 'guess_radius',

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -29,7 +29,7 @@ from typing_extensions import Literal
 from .. import config, graph, sampling, core, utils
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['strahler_index', 'bending_flow', 'sholl_analysis',
                   'flow_centrality', 'synapse_flow_centrality',

--- a/navis/morpho/persistence.py
+++ b/navis/morpho/persistence.py
@@ -31,7 +31,7 @@ from .. import utils, config, core, graph
 
 
 # Setup logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 @utils.map_neuronlist(desc='Calc. persistence', allow_parallel=True)

--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -21,7 +21,7 @@ from typing import Union, Sequence
 from .. import utils, config, core, graph
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['subset_neuron'])
 

--- a/navis/nbl/nblast_funcs.py
+++ b/navis/nbl/nblast_funcs.py
@@ -39,7 +39,7 @@ __all__ = ['nblast', 'nblast_smart', 'nblast_allbyall', 'sim_to_dist']
 fp = os.path.dirname(__file__)
 smat_path = os.path.join(fp, 'score_mats')
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # This multiplier controls job size for NBLASTs (only relevant for
 # multiprocessing and if progress=True).

--- a/navis/nbl/synblast_funcs.py
+++ b/navis/nbl/synblast_funcs.py
@@ -39,7 +39,7 @@ __all__ = ['synblast']
 fp = os.path.dirname(__file__)
 smat_path = os.path.join(fp, 'score_mats')
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 class SynBlaster(Blaster):

--- a/navis/plotting/colors.py
+++ b/navis/plotting/colors.py
@@ -32,7 +32,7 @@ __all__ = ['generate_colors', 'prepare_connector_cmap', 'prepare_colormap',
            'eval_color', 'hex_to_rgb', 'vary_colors', 'vertex_colors',
            'color_to_int']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # Some definitions for mypy
 RGB_color = Tuple[float, float, float]

--- a/navis/plotting/d.py
+++ b/navis/plotting/d.py
@@ -24,7 +24,7 @@ from typing import Optional, Union, Dict, Tuple, Any
 
 from .. import core, config, graph
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 colortype = Union[str,
                   Tuple[float, float, float],

--- a/navis/plotting/dd.py
+++ b/navis/plotting/dd.py
@@ -38,7 +38,7 @@ from .plot_utils import segments_to_coords, tn_pairs_to_coords
 
 __all__ = ['plot2d']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")

--- a/navis/plotting/ddd.py
+++ b/navis/plotting/ddd.py
@@ -32,7 +32,7 @@ from .plotly.graph_objs import (neuron2plotly, volume2plotly, scatter2plotly,
 
 __all__ = ['plot3d']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def plot3d(x: Union[core.NeuronObject,

--- a/navis/plotting/flat.py
+++ b/navis/plotting/flat.py
@@ -30,7 +30,7 @@ from ..morpho.mmetrics import parent_dist
 
 from .colors import prepare_connector_cmap
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['plot_flat']
 

--- a/navis/plotting/k3d/k3d_objects.py
+++ b/navis/plotting/k3d/k3d_objects.py
@@ -24,7 +24,7 @@ from ..colors import vertex_colors, eval_color, color_to_int
 from ..plot_utils import segments_to_coords, fibonacci_sphere
 from ... import core, utils, config, conversion
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['neuron2k3d', 'scatter2k3d', 'dotprops2k3d', 'voxel2k3d',
            'volume2k3d']

--- a/navis/plotting/plot_utils.py
+++ b/navis/plotting/plot_utils.py
@@ -33,7 +33,7 @@ with warnings.catch_warnings():
 
 __all__ = ['tn_pairs_to_coords', 'segments_to_coords', 'fibonacci_sphere', 'make_tube']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def tn_pairs_to_coords(x: core.TreeNeuron,

--- a/navis/plotting/plotly/graph_objs.py
+++ b/navis/plotting/plotly/graph_objs.py
@@ -26,7 +26,7 @@ from ..colors import vertex_colors, prepare_colormap, eval_color
 from ..plot_utils import segments_to_coords, fibonacci_sphere
 from ... import core, utils, config, conversion
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['neuron2plotly', 'scatter2plotly', 'dotprops2plotly',
            'volume2plotly', 'layout2plotly']

--- a/navis/plotting/vispy/browser.py
+++ b/navis/plotting/vispy/browser.py
@@ -32,7 +32,7 @@ from ... import utils, config
 
 __all__ = ['Viewer']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 class Browser:

--- a/navis/plotting/vispy/viewer.py
+++ b/navis/plotting/vispy/viewer.py
@@ -35,7 +35,7 @@ from .visuals import *
 
 __all__ = ['Viewer']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def block_all(function):

--- a/navis/plotting/vispy/visuals.py
+++ b/navis/plotting/vispy/visuals.py
@@ -36,7 +36,7 @@ with warnings.catch_warnings():
 __all__ = ['volume2vispy', 'neuron2vispy', 'dotprop2vispy', 'voxel2vispy',
            'points2vispy', 'combine_visuals']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def volume2vispy(x, **kwargs):

--- a/navis/sampling/downsampling.py
+++ b/navis/sampling/downsampling.py
@@ -20,7 +20,7 @@ from typing import Optional, Union, List
 from .. import config, graph, core, utils, meshes
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['downsample_neuron']
 

--- a/navis/sampling/resampling.py
+++ b/navis/sampling/resampling.py
@@ -25,7 +25,7 @@ from typing_extensions import Literal
 from .. import config, core, utils, graph
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['resample_skeleton', 'resample_along_axis']
 

--- a/navis/transforms/base.py
+++ b/navis/transforms/base.py
@@ -21,6 +21,8 @@ from inspect import signature
 
 from .. import utils, config
 
+logger = config.get_logger(__name__)
+
 
 def trigger_init(func):
     """Trigger delayed initialization."""
@@ -315,7 +317,7 @@ class TransOptimizer:
             return
 
         if not config.pbar_hide:
-            config.logger.info('Pre-caching deformation field(s) for transforms...')
+            logger.info('Pre-caching deformation field(s) for transforms...')
 
         bbox_xf = self.bbox
         for tr in self.transforms:

--- a/navis/transforms/h5reg.py
+++ b/navis/transforms/h5reg.py
@@ -27,7 +27,7 @@ from .affine import AffineTransform
 
 from .. import config
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 class H5transform(BaseTransform):

--- a/navis/transforms/templates.py
+++ b/navis/transforms/templates.py
@@ -49,7 +49,7 @@ with warnings.catch_warnings():
 
 __all__ = ['xform_brain', 'mirror_brain', 'symmetrize_brain']
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # Defines entry the registry needs to register a transform
 transform_reg = namedtuple('Transform',

--- a/navis/transforms/xfm_funcs.py
+++ b/navis/transforms/xfm_funcs.py
@@ -27,7 +27,7 @@ from .. import utils, core, config
 from .base import BaseTransform, TransformSequence, TransOptimizer
 from .affine import AffineTransform
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def xform(x: Union['core.NeuronObject', 'pd.DataFrame', 'np.ndarray'],

--- a/navis/utils/cv.py
+++ b/navis/utils/cv.py
@@ -16,7 +16,7 @@ import functools
 from .. import config, core, io
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def patch_cloudvolume():

--- a/navis/utils/eval.py
+++ b/navis/utils/eval.py
@@ -23,7 +23,7 @@ from .. import config, core
 from .iterables import make_iterable
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # Boolean, unsigned integer, signed integer, float, complex.
 _NUMERIC_KINDS = set('buifc')

--- a/navis/utils/misc.py
+++ b/navis/utils/misc.py
@@ -31,7 +31,7 @@ from .iterables import is_iterable, make_iterable
 from ..transforms.templates import TemplateBrain
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def round_smart(num: Union[int, float], prec: int = 8) -> float:

--- a/navis/utils/validate.py
+++ b/navis/utils/validate.py
@@ -20,7 +20,7 @@ from .. import config, core
 from .iterables import *
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def validate_options(x: 'core.TreeNeuron',


### PR DESCRIPTION
As mentioned in https://github.com/navis-org/pymaid/pull/226 , conventionally loggers use the module's qualified name, allowing users to see where the logs are coming from and have more control over filtering them. This change keeps the current log config unless NAVIS_SKIP_LOG_SETUP is used, in which case module-level loggers are used.