### PR TITLE
Add tags=None to TreeNeurons

### DIFF
--- a/navis/core/skeleton.py
+++ b/navis/core/skeleton.py
@@ -119,6 +119,8 @@ class TreeNeuron(BaseNeuron):
     # Set default function for soma finding. Default = :func:`navis.morpho.find_soma`
     _soma: Union[Callable[['TreeNeuron'], Sequence[int]], int] = morpho.find_soma
 
+    tags: Optional[Dict[str, List[int]]] = None
+
     #: Attributes to be used when comparing two neurons.
     EQ_ATTRIBUTES = ['n_nodes', 'n_connectors', 'soma', 'root',
                      'n_branches', 'n_leafs', 'cable_length', 'name']

--- a/navis/graph/graph_utils.py
+++ b/navis/graph/graph_utils.py
@@ -1180,6 +1180,9 @@ def reroot_skeleton(x: 'core.NeuronObject',
 
         # If new root is a tag, rather than a ID, try finding that node
         if isinstance(root, str):
+            if x.tags is None:
+                raise ValueError("Neuron does not have tags")
+
             if root not in x.tags:
                 raise ValueError(f'#{x.id}: Found no nodes with tag {root}'
                                  ' - please double check!')
@@ -1416,6 +1419,8 @@ def cut_skeleton(x: 'core.NeuronObject',
     for cn in where:
         # If cut_node is a tag (rather than an ID), try finding that node
         if isinstance(cn, str):
+            if x.tags is None:
+                raise ValueError(f"Neuron {x.id} has no tags")
             if cn not in x.tags:
                 raise ValueError(f'#{x.id}: Found no node with tag {cn}'
                                  ' - please double check!')

--- a/navis/morpho/manipulation.py
+++ b/navis/morpho/manipulation.py
@@ -1085,7 +1085,7 @@ def stitch_skeletons(*x: Union[Sequence[NeuronObject], 'core.NeuronList'],
                 if n.has_connectors:
                     n.connectors['node_id'] = n.connectors.node_id.map(lambda x: new_map.get(x, x))
 
-                if hasattr(n, 'tags'):
+                if getattr(n, 'tags', None) is not None:
                     n.tags = {new_map.get(k, k): v for k, v in n.tags.items()}  # type: ignore
 
                 # Remap parent IDs
@@ -1110,7 +1110,7 @@ def stitch_skeletons(*x: Union[Sequence[NeuronObject], 'core.NeuronList'],
         m.tags = {}  # type: ignore  # TreeNeuron has no tags
 
     for n in nl:
-        for k, v in getattr(n, 'tags', {}).items():
+        for k, v in (getattr(n, 'tags', None) or {}).items():
             m.tags[k] = m.tags.get(k, []) + list(utils.make_iterable(v))
 
     # Reset temporary attributes of our final neuron

--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -283,7 +283,7 @@ def _subset_treeneuron(x, subset, keep_disc_cn, prevent_fragments):
         x._connectors = x.connectors[x.connectors.node_id.isin(subset)]
         x._connectors.reset_index(inplace=True, drop=True)
 
-    if hasattr(x, 'tags'):
+    if getattr(x, 'tags', None) is not None:
         # Filter tags
         x.tags = {t: [tn for tn in x.tags[t] if tn in subset] for t in x.tags}  # type: ignore  # TreeNeuron has no tags
 


### PR DESCRIPTION
Some navis functions expect TreeNeurons to have a `tags` attribute, or at least check whether it exists, presumably to catch subclasses like CatmaidNeurons. This effectively blesses that tag representation, so we may as well include it in the base class. For me at least, it's convenient to be able to represent tags without needing the live-fetching elements from CatmaidNeurons, so this change adds `tags = None` to the TreeNeuron class definition, and has other functions check whether it's non-None before trying to read anything from it. Having an optional attribute for tags, rather than an empty dict, means you can distinguish between untagged neurons and neurons which happen to have 0 tags; but having a firm attribute in place for it makes type checkers more happy.