### PR TITLE
models: fix Bayesian traversal model and test

### DIFF
--- a/tests/test_models/test_network_models.py
+++ b/tests/test_models/test_network_models.py
@@ -1,0 +1,31 @@
+import pytest
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+from navis.models.network_models import (TraversalModel, BayesianTraversalModel)
+
+def test_traversal_models():
+    models = (TraversalModel, BayesianTraversalModel)
+
+    G = nx.path_graph(10, create_using=nx.DiGraph)
+    G.add_edge(0, 9)
+    G.add_node(10)
+    edges = nx.to_pandas_edgelist(G)
+    edges['weight'] = np.ones(edges.shape[0])
+
+    results = {}
+    for m in models:
+        model = m(edges, seeds=[1], max_steps=8)
+        model.run(iterations=1)
+        res = model.summary
+        assert 0 not in res.index
+        assert 9 not in res.index
+        assert 10 not in res.index
+        for i in range(1, 9):
+            row = res.loc[i]
+            assert row.layer_min == row.layer_max
+        results[m] = res
+
+    for m in models:
+        pd.testing.assert_frame_equal(results[TraversalModel], results[m])


### PR DESCRIPTION
- Fix Bayesian traversal choosing entirely the wrong edges as seed edges
  (!)
- Fix Bayesian traversal summary values for nodes whose activation CMF
  never reaches 1.
- Do not include disconnected nodes in Bayesian traversal summary.
- Make Bayesian traversal consistent with the sampling model.
- Test all of the above.
