### PR TITLE
Skip plotting empty TreeNeuron in plotly

### DIFF
--- a/navis/plotting/plotly/graph_objs.py
+++ b/navis/plotting/plotly/graph_objs.py
@@ -350,7 +350,7 @@ def voxel2plotly(neuron, legendgroup, showlegend, label, color,
 
 def skeleton2plotly(neuron, legendgroup, showlegend, label, color, **kwargs):
     """Convert skeleton (i.e. TreeNeuron) to plotly line plot."""
-    if hasattr(neuron, 'nodes') and neuron.nodes.empty:
+    if not hasattr(neuron, 'nodes') or neuron.nodes.empty:
         logger.warning(f'Skipping TreeNeuron w/o nodes: {neuron.label}')
         return []
     elif neuron.nodes.shape[0] == 1:

--- a/navis/plotting/plotly/graph_objs.py
+++ b/navis/plotting/plotly/graph_objs.py
@@ -350,7 +350,7 @@ def voxel2plotly(neuron, legendgroup, showlegend, label, color,
 
 def skeleton2plotly(neuron, legendgroup, showlegend, label, color, **kwargs):
     """Convert skeleton (i.e. TreeNeuron) to plotly line plot."""
-    if neuron.nodes.empty:
+    if hasattr(neuron, 'nodes') and neuron.nodes.empty:
         logger.warning(f'Skipping TreeNeuron w/o nodes: {neuron.label}')
         return []
     elif neuron.nodes.shape[0] == 1:


### PR DESCRIPTION

Previously this would throw an `AttributeError` during plotly plotting in the `skeleton2plotly` method while trying to access non-existing `neuron.nodes`.
```
empty_skel = navis.TreeNeuron(None)
navis.plot3d(empty_skel)
```

This tiny fix now skips plotting this TreeNeuron.