### PR TITLE
CI: Update python versions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,27 +10,27 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install wheel and setuptools
-      run: >-
-        python -m
-        pip install
-        wheel
-        setuptools
-        extreqs
-        --user
-        --upgrade
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python3
-        setup.py
-        sdist
-        bdist_wheel
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.pypi_password }}
+      - uses: actions/checkout@master
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10
+      - name: Install wheel and setuptools
+        run: >-
+          python -m
+          pip install
+          wheel
+          setuptools
+          extreqs
+          --user
+          --upgrade
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python3
+          setup.py
+          sdist
+          bdist_wheel
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -16,31 +16,30 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       # This cancels any such job that is still runnning
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.6.0
-      with:
-        access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Linux libraries
-      run: |
-        sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-          libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-          libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip wheel
-    - name: Install navis from Github
-      run: pip install git+https://github.com/navis-org/navis@master
-    - name: Test import
-      run: python3 -c "import navis"
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Linux libraries
+        run: |
+          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
+            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
+            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip wheel
+      - name: Install navis from Github
+        run: pip install git+https://github.com/navis-org/navis@master
+      - name: Test import
+        run: python3 -c "import navis"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -19,7 +19,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
+          # - "3.12"
     runs-on: ${{ matrix.os }}
     steps:
       # This cancels any such job that is still runnning

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -18,6 +18,8 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
     runs-on: ${{ matrix.os }}
     steps:
       # This cancels any such job that is still runnning

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -11,6 +11,8 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
         igraph: ["igraph", "no-igraph"]
     steps:
       # This cancels any such job that is still runnning

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -11,7 +11,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
+          # - "3.12"
         igraph: ["igraph", "no-igraph"]
     steps:
       # This cancels any such job that is still runnning

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
+          # - "3.12"
         igraph: ["igraph", "no-igraph"]
     steps:
       # This cancels any such job that is still runnning

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -11,7 +11,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12"
+          - "3.12"
         igraph: ["igraph", "no-igraph"]
     steps:
       # This cancels any such job that is still runnning

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -17,7 +17,8 @@ repository.
      -
    * - dev
      - ongoing
-     - - Additions:
+     - - BREAKING: dropped support for Python 3.8, per `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_
+       - Additions:
           - new property ``Treenode.surface_area``
           - new functions :func:`navis.read_parquet` and :func:`navis.write_parquet`
             store skeletons and dotprops in parquet files (see

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
@@ -74,7 +73,7 @@ setup(
     extras_require=dict(extras_require),
     tests_require=extras_require["dev"],
     # CI runs against >=3.8
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     zip_safe=False,
 
     include_package_data=True

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
+        # 'Programming Language :: Python :: 3.12',
     ],
     install_requires=install_requires,
     extras_require=dict(extras_require),

--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,14 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     install_requires=install_requires,
     extras_require=dict(extras_require),
     tests_require=extras_require["dev"],
     # CI runs against >=3.8
-    python_requires='>=3.9',
+    python_requires='>=3.9,<4.0',
     zip_safe=False,
 
     include_package_data=True


### PR DESCRIPTION
Updating the test matrix, we'll see what falls out...

Updates one-off workflows (e.g. deploy) to use 3.10, and updates the test matrix otherwise.

Also reformats some YAML, unfortunately.

- Python 3.8 is not yet EOL but has been dropped by numpy releases since Apr 2023
- 3.11 was released Oct 2022
- 3.12 was released Oct 2023