### PR TITLE
Test against python 3.12

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -19,7 +19,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12"
+          - "3.12"
     runs-on: ${{ matrix.os }}
     steps:
       # This cancels any such job that is still runnning

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -11,42 +11,42 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12"
+          - "3.12"
         igraph: ["igraph", "no-igraph"]
     steps:
       # This cancels any such job that is still runnning
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.6.0
-      with:
-        access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Linux libraries
-      run: |
-        sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-          libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-          libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 graphviz graphviz-dev
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install zstandard==0.16.0
-        pip install numpy
-        pip install flybrains --no-deps
-        pip install git+https://github.com/siavashk/pycpd@master
-        pip install k3d
-        pip install pyarrow
-    - name: Install navis
-      run: pip install -e .[dev,vispy-pyqt5,pathos,cloudvolume]
-    - run: pip install python-igraph
-      if: ${{ matrix.igraph == 'igraph' }}
-    - name: Report dependency versions
-      run: pip freeze -r requirements.txt
-    - name: Test
-      uses: GabrielBB/xvfb-action@v1
-      with:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Linux libraries
         run: |
-          export NAVIS_HEADLESS=TRUE
-          pytest --verbose
+          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
+            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
+            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 graphviz graphviz-dev
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install zstandard==0.16.0
+          pip install numpy
+          pip install flybrains --no-deps
+          pip install git+https://github.com/siavashk/pycpd@master
+          pip install k3d
+          pip install pyarrow
+      - name: Install navis
+        run: pip install -e .[dev,vispy-pyqt5,pathos,cloudvolume]
+      - run: pip install python-igraph
+        if: ${{ matrix.igraph == 'igraph' }}
+      - name: Report dependency versions
+        run: pip freeze -r requirements.txt
+      - name: Test
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: |
+            export NAVIS_HEADLESS=TRUE
+            pytest --verbose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=3.1
 matplotlib>=3.6
 morphops>=0.1.11
-ncollpyde>=0.18
+ncollpyde>=0.18,<0.20
 networkx>=2.4
 numpy>=1.16
 pandas>=1.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        # 'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.12',
     ],
     install_requires=install_requires,
     extras_require=dict(extras_require),


### PR DESCRIPTION
Also pins ncollpyde to <v0.20, and formats some YAML.

The previous blocker for python 3.12 was cloudvolume, which had several dependencies which did not specify a build system and so could not be installed. This is hopefully now resolved https://github.com/seung-lab/cloud-volume/issues/606#issuecomment-1894316509