### PR TITLE
fixes for neuromorpho interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ molesq>=0.2.0
 rdata>=0.5
 igraph!=0.10.0,!=0.10.1
 skeletor>=1.0.0
+pycurl>=7.45.3
 
 pathos>=0.2.7 #extra: pathos
 


### PR DESCRIPTION
This PR fixes errors in the navis _neuromorpho_ interface. It seems like one of the URLs was deprecated, so I added the new, up-to-date one (http://cng.gmu.edu:8080/). Also, `get_neuron` previously threw an SSL error when requesting .swc files from the `neuromorpho` server. I added a workaround that pulls the files using `pycurl`, which works more reliably. 