### PR TITLE
Improve subset neurons

### DIFF
--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -197,16 +197,24 @@ def _subset_dotprops(x, subset, keep_disc_cn):
 def _subset_meshneuron(x, subset, keep_disc_cn, prevent_fragments):
     """Subset MeshNeuron."""
     if not utils.is_iterable(subset):
-        raise TypeError('Can only subset MeshNeuron to list, set or '
-                        f'numpy.ndarray, not "{type(subset)}"')
+        raise TypeError(
+            "Can only subset MeshNeuron to list, set or "
+            f'numpy.ndarray, not "{type(subset)}"'
+        )
 
     subset = utils.make_iterable(subset)
 
-    # Convert mask to indices
+    # Convert mask to vertex indices
     if subset.dtype == bool:
-        if subset.shape != (x.vertices.shape[0], ):
-            raise ValueError('Boolean mask must be of same length as vertices.')
-        subset = np.arange(0, len(x.vertices))[subset]
+        if subset.shape[0] == x.vertices.shape[0]:
+            subset = np.arange(len(x.vertices))[subset]
+        elif subset.shape[0] == x.faces.shape[0]:
+            # Translate face mask to vertex indices
+            subset = np.unique(x.faces[subset])
+        else:
+            raise ValueError(
+                "Boolean mask must be of same length as vertices or faces."
+            )
 
     if prevent_fragments:
         # Generate skeleton

--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -23,18 +23,18 @@ from .. import utils, config, core, graph
 # Set up logging
 logger = config.get_logger(__name__)
 
-__all__ = sorted(['subset_neuron'])
+__all__ = sorted(["subset_neuron"])
 
 
+@utils.map_neuronlist(desc="Subsetting", allow_parallel=True)
 @utils.lock_neuron
-def subset_neuron(x: Union['core.TreeNeuron', 'core.MeshNeuron'],
+def subset_neuron(
     x: Union["core.TreeNeuron", "core.MeshNeuron"],
     subset: Union[Sequence[Union[int, str]], nx.DiGraph, pd.DataFrame, Callable],
-                                pd.DataFrame],
-                  inplace: bool = False,
-                  keep_disc_cn: bool = False,
-                  prevent_fragments: bool = False
-                  ) -> 'core.NeuronObject':
+    inplace: bool = False,
+    keep_disc_cn: bool = False,
+    prevent_fragments: bool = False,
+) -> "core.NeuronObject":
     """Subset a neuron to a given set of nodes/vertices.
 
     Note that for ``MeshNeurons`` it is not guaranteed that all vertices in
@@ -43,8 +43,9 @@ def subset_neuron(x: Union['core.TreeNeuron', 'core.MeshNeuron'],
 
     Parameters
     ----------
-    x :                   TreeNeuron | MeshNeuron | Dotprops
-                          Neuron to subset.
+    x :                   TreeNeuron | MeshNeuron | Dotprops | NeuronList
+                          Neuron to subset. When passing a NeuronList, it's advised
+                          to use a function for `subset` (see below).
     subset :              list-like | set | NetworkX.Graph | pandas.DataFrame | Callable
                           Subset of the neuron to keep. Depending on the neuron:
                             For TreeNeurons:
@@ -74,7 +75,7 @@ def subset_neuron(x: Union['core.TreeNeuron', 'core.MeshNeuron'],
 
     Returns
     -------
-    TreeNeuron | MeshNeuron
+    TreeNeuron | MeshNeuron | Dotprops | NeuronList
 
     Examples
     --------

--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -91,7 +91,17 @@ def subset_neuron(
     >>> # Flatten segments into list of nodes
     >>> nodes_to_keep = [n for s in short_segs for n in s]
     >>> # Subset neuron
-    >>> n_short = navis.subset_neuron(n, nodes_to_keep)
+    >>> n_short = navis.subset_neuron(n, subset=nodes_to_keep)
+
+    Subset multiple neurons using a callable
+
+    >>> import navis
+    >>> nl = navis.example_neurons(2)
+    >>> # Subset neurons to all leaf nodes
+    >>> nl_end = navis.subset_neuron(
+    ...     nl,
+    ...     subset=lambda x: x.leafs.node_id
+    ... )
 
     See Also
     --------


### PR DESCRIPTION
This PR improves the `subset_neuron` function:
1. Now works with multiple neurons at a time (previously accepted only single neurons)
2. `subset` can now be a callable
3. Re-implements the `submesh` function to reduce memory footprint when subsetting meshes (addresses #154) 