### PR TITLE
Masking

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,13 +47,13 @@ learn more!
 ``TreeNeurons``, ``MeshNeurons``, ``VoxelNeurons`` and ``Dotprops`` are neuron
 classes. ``NeuronLists`` are containers thereof.
 
-| Class | Description |
-|------|------|
-| [`navis.TreeNeuron`][] | Skeleton representation of a neuron. |
-| [`navis.MeshNeuron`][] | Meshes with vertices and faces. |
-| [`navis.VoxelNeuron`][] | 3D images (e.g. from confocal stacks). |
-| [`navis.Dotprops`][] | Point cloud + vector representations, used for NBLAST. |
-| [`navis.NeuronList`][] | Containers for neurons. |
+| Class                   | Description                                             |
+|-------------------------|---------------------------------------------------------|
+| [`navis.TreeNeuron`][]  | Skeleton representation of a neuron.                    |
+| [`navis.MeshNeuron`][]  | Meshes with vertices and faces.                         |
+| [`navis.VoxelNeuron`][] | 3D images (e.g. from confocal stacks).                  |
+| [`navis.Dotprops`][]    | Point cloud + vector representations, used for NBLAST.  |
+| [`navis.NeuronList`][]  | Containers for neurons.                                 |
 
 ### General Neuron methods
 
@@ -89,6 +89,7 @@ to all neurons:
 | `Neuron.type` | {{ autosummary("navis.BaseNeuron.type") }} |
 | `Neuron.soma` | {{ autosummary("navis.BaseNeuron.soma") }} |
 | `Neuron.bbox` | {{ autosummary("navis.BaseNeuron.bbox") }} |
+| `Neuron.is_masked` | {{ autosummary("navis.BaseNeuron.is_masked") }} |
 
 !!! note
 
@@ -119,6 +120,8 @@ this neuron type. Note that most of them are simply short-hands for the other
 | [`TreeNeuron.reroot()`][navis.TreeNeuron.reroot] | {{ autosummary("navis.TreeNeuron.reroot") }} |
 | [`TreeNeuron.resample()`][navis.TreeNeuron.resample] | {{ autosummary("navis.TreeNeuron.resample") }} |
 | [`TreeNeuron.snap()`][navis.TreeNeuron.snap] | {{ autosummary("navis.TreeNeuron.snap") }} |
+| [`TreeNeuron.mask()`][navis.TreeNeuron.mask] | {{ autosummary("navis.TreeNeuron.mask") }} |
+| [`TreeNeuron.unmask()`][navis.TreeNeuron.unmask] | {{ autosummary("navis.TreeNeuron.unmask") }} |
 
 In addition, a [`navis.TreeNeuron`][] has a range of different properties:
 
@@ -146,7 +149,6 @@ In addition, a [`navis.TreeNeuron`][] has a range of different properties:
 | [`TreeNeuron.vertices`][navis.TreeNeuron.vertices] | {{ autosummary("navis.TreeNeuron.vertices") }} |
 | [`TreeNeuron.volume`][navis.TreeNeuron.volume] | {{ autosummary("navis.TreeNeuron.volume") }} |
 
-
 #### Skeleton utility functions
 
 | Function | Description |
@@ -156,7 +158,6 @@ In addition, a [`navis.TreeNeuron`][] has a range of different properties:
 | [`navis.remove_nodes()`][navis.remove_nodes] | {{ autosummary("navis.remove_nodes") }} |
 | [`navis.graph.simplify_graph()`][navis.graph.simplify_graph] | {{ autosummary("navis.graph.simplify_graph") }} |
 | [`navis.graph.skeleton_adjacency_matrix()`][navis.graph.skeleton_adjacency_matrix] | {{ autosummary("navis.graph.skeleton_adjacency_matrix") }} |
-
 
 
 ### Mesh neurons
@@ -178,6 +179,8 @@ Methods specific to [`navis.MeshNeuron`][]:
 | [`MeshNeuron.skeletonize()`][navis.MeshNeuron.skeletonize] | {{ autosummary("navis.MeshNeuron.skeletonize") }} |
 | [`MeshNeuron.snap()`][navis.MeshNeuron.snap] | {{ autosummary("navis.MeshNeuron.snap") }} |
 | [`MeshNeuron.validate()`][navis.MeshNeuron.validate] | {{ autosummary("navis.MeshNeuron.validate") }} |
+| [`MeshNeuron.mask()`][navis.MeshNeuron.mask] | {{ autosummary("navis.MeshNeuron.mask") }} |
+| [`MeshNeuron.unmask()`][navis.MeshNeuron.unmask] | {{ autosummary("navis.MeshNeuron.unmask") }} |
 
 
 ### Voxel neurons
@@ -215,6 +218,8 @@ These are methods and properties specific to [Dotprops][navis.Dotprops]:
 | [`Dotprops.alpha`][navis.Dotprops.alpha] | {{ autosummary("navis.Dotprops.alpha") }} |
 | [`Dotprops.to_skeleton()`][navis.Dotprops.to_skeleton] | {{ autosummary("navis.Dotprops.to_skeleton") }} |
 | [`Dotprops.snap()`][navis.Dotprops.snap] | {{ autosummary("navis.Dotprops.snap") }} |
+| [`Dotprops.mask()`][navis.Dotprops.mask] | {{ autosummary("navis.Dotprops.mask") }} |
+| [`Dotprops.unmask()`][navis.Dotprops.unmask] | {{ autosummary("navis.Dotprops.unmask") }} |
 
 ### Converting between types
 

--- a/navis/core/__init__.py
+++ b/navis/core/__init__.py
@@ -18,11 +18,22 @@ from .mesh import MeshNeuron
 from .dotprop import Dotprops
 from .voxel import VoxelNeuron
 from .neuronlist import NeuronList
+from .masking import NeuronMask
 from .core_utils import make_dotprops, to_neuron_space, NeuronProcessor
 
 from typing import Union
 
 NeuronObject = Union[NeuronList, TreeNeuron, BaseNeuron, MeshNeuron]
 
-__all__ = ['Volume', 'Neuron', 'BaseNeuron', 'TreeNeuron', 'MeshNeuron',
-           'Dotprops', 'VoxelNeuron', 'NeuronList', 'make_dotprops']
+__all__ = [
+    "Volume",
+    "Neuron",
+    "BaseNeuron",
+    "TreeNeuron",
+    "MeshNeuron",
+    "NeuronMask",
+    "Dotprops",
+    "VoxelNeuron",
+    "NeuronList",
+    "make_dotprops",
+]

--- a/navis/core/masking.py
+++ b/navis/core/masking.py
@@ -1,0 +1,204 @@
+#    This script is part of navis (http://www.github.com/navis-org/navis).
+#    Copyright (C) 2018 Philipp Schlegel
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+import numpy as np
+import pandas as pd
+
+from .neuronlist import NeuronList
+from .skeleton import TreeNeuron
+from .dotprop import Dotprops
+from .voxel import VoxelNeuron
+from .mesh import MeshNeuron
+
+from .. import utils
+
+__all__ = ["NeuronMask"]
+
+# mode = "r"\w"?
+class NeuronMask:
+    """Mask neuron(s) by a specific property.
+
+    Parameters
+    ----------
+        x :     Neuron/List
+                Neuron(s) to mask.
+    mask :      str | array | callable | list | dict
+                The mask to apply:
+                - str: The name of the property to mask by
+                - array: boolean mask
+                - callable: A function that takes a neuron as input
+                and returns a boolean mask
+                - list: a list of the above
+                - dict: a dictionary mapping neuron IDs to one of the
+                above
+    copy_data : bool
+                Whether to copy the neuron data (e.g. node table for skeletons)
+                when masking. Setting this to False will may some time and
+                memory but may lead to e.g. pandas setting-on-copy warnings
+                if the data is modified. Only set to `True` if you know your
+                code won't modify the data.
+    reset_neurons : bool
+                If True, reset the neurons to their original state after the
+                context manager exits. If False, will try to incorporate any
+                changes made to the masked neurons. Note that this may not
+                work for destructive operations.
+    validate_mask : bool
+                If True, validate `mask` against the neurons before setting it.
+                This is recommended but can come with an overhead (in particular
+                if `mask` is a callable).
+
+    Examples
+    --------
+    >>> import navis
+    >>> # Grab a few skeletons
+    >>> nl = navis.example_neurons(3)
+    >>> # Label axon and dendrites
+    >>> navis.split_axon_dendrite(nl, label_only=True)
+    >>> # Mask by axon
+    >>> with navis.NeuronMask(nl, lambda x: x.nodes.compartment == 'axon'):
+    ...    print("Axon cable length:", nl.cable_length * nl[0].units)
+    Axon cable length: [363469.75 411147.1875 390231.8125] nanometer
+    >>> # Mask by dendrite
+    >>> with navis.NeuronMask(nl, lambda x: x.nodes.compartment == 'dendrite'):
+    ...    print("Dendrite cable length:", nl.cable_length * nl[0].units)
+    Dendrite cable length: [1410770.0 1612187.25 1510453.875] nanometer
+
+    See Also
+    --------
+    [`navis.BaseNeuron.is_masked`][]
+            Check if a neuron is masked. Property exists for all neuron types.
+    [`navis.BaseNeuron.mask`][]
+            Mask a neuron. Implementation details depend on the neuron type.
+    [`navis.BaseNeuron.unmask`][]
+            Unmask a neuron. Implementation details depend on the neuron type.
+
+    """
+
+    def __init__(self, x, mask, reset_neurons=True, copy_data=True, validate_mask=True):
+        self.neurons = x
+
+        if validate_mask:
+            self.mask = mask
+        else:
+            self._mask = mask
+
+        self.reset = reset_neurons
+        self.copy = copy_data
+
+    @property
+    def neurons(self):
+        return self._neurons
+
+    @neurons.setter
+    def neurons(self, value):
+        self._neurons = NeuronList(value)
+
+        if any(n.is_masked for n in self._neurons):
+            raise MaskingError("At least some neuron(s) are already masked")
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, mask):
+        # Validate the mask
+        if isinstance(mask, str):
+            for n in self.neurons:
+                if isinstance(n, TreeNeuron):
+                    if mask not in n.nodes.columns:
+                        raise MaskingError(f"Neuron does not have '{mask}' column")
+                elif not hasattr(n, mask):
+                    raise MaskingError(f"Neuron does not have '{mask}' attribute")
+        elif isinstance(mask, (list, np.ndarray, pd.Series)):
+            if len(self.neurons) == 1 and len(mask) != 1:
+                # If we only have one neuron, we can accept a single mask
+                # but we still want to wrap it in a list for consistency
+                mask = [np.asarray(mask)]
+
+            if len(mask) != len(self.neurons):
+                raise MaskingError("Number of masks does not match number of neurons")
+
+            # Validate each mask
+            for m, n in zip(mask, self.neurons):
+                validate_mask_length(m, n)
+        elif isinstance(mask, dict):
+            for n in self.neurons:
+                if n.id not in mask:
+                    raise MaskingError(f"Neuron {n.id} not in mask dictionary")
+                validate_mask_length(mask[n.id], n)
+        elif callable(mask):
+            # If this is a function, try calling it on the first neuron
+            test = mask(self.neurons[0])
+            if not isinstance(test, (pd.Series, np.ndarray)) or test.dtype != bool:
+                raise MaskingError("Callable mask must return a boolean array")
+            validate_mask_length(test, self.neurons[0])
+        else:
+            raise MaskingError(f"Unexpected mask type: {type(mask)}")
+
+        self._mask = mask
+
+    def __enter__(self):
+        for i, n in enumerate(self.neurons):
+            if callable(self.mask):
+                mask = self.mask(n)
+            elif isinstance(self.mask, dict):
+                mask = self.mask[n.id]
+            elif isinstance(self.mask, str):
+                mask = self.mask
+            else:
+                mask = self.mask[i]
+
+            n.mask(mask, copy=self.copy)
+
+        return self
+
+    def __exit__(self, *args):
+        for i, n in enumerate(self.neurons):
+            n.unmask(reset=self.reset)
+
+
+def validate_mask_length(mask, neuron):
+    """Validate mask length for a given neuron."""
+    if callable(mask):
+        mask = mask(neuron)
+    elif isinstance(mask, str):
+        if isinstance(neuron, TreeNeuron):
+            mask = neuron.nodes[mask]
+        else:
+            mask = getattr(neuron, mask)
+
+    if isinstance(mask, list):
+        mask = np.asarray(mask)
+
+    if not isinstance(mask, (np.ndarray, pd.Series)) or mask.dtype != bool:
+        raise MaskingError("Mask must be a boolean array")
+
+    if isinstance(neuron, TreeNeuron):
+        if len(mask) != len(neuron.nodes):
+            raise MaskingError("Mask length does not match number of nodes")
+    elif isinstance(neuron, VoxelNeuron):
+        if neuron._base_data_type == "grid" and mask.shape != neuron.shape:
+            raise MaskingError("Mask shape does not match voxel shape")
+        elif len(neuron.voxels) != len(mask):
+            raise MaskingError("Mask length does not match number of voxels")
+    elif isinstance(neuron, Dotprops):
+        if len(mask) != len(neuron.points):
+            raise MaskingError("Mask length does not match number of points")
+    elif isinstance(neuron, MeshNeuron):
+        if len(mask) != len(neuron.vertices):
+            raise MaskingError("Mask length does not match number of vertices")
+
+
+class MaskingError(Exception):
+    pass

--- a/navis/core/voxel.py
+++ b/navis/core/voxel.py
@@ -94,6 +94,9 @@ class VoxelNeuron(BaseNeuron):
     #: Core data table(s) used to calculate hash
     CORE_DATA = ['_data']
 
+    #: Property used to calculate length of neuron
+    _LENGTH_DATA = 'voxels'
+
     def __init__(self,
                  x: Union[np.ndarray],
                  offset: Optional[np.ndarray] = None,
@@ -215,6 +218,12 @@ class VoxelNeuron(BaseNeuron):
 
             return n
         return NotImplemented
+
+    def __len__(self):
+        """Return number of voxels."""
+        # This is the only neuron for which we implement __len__ separately
+        # to avoid the potential overhead of generating the voxel representation
+        return np.product(self.shape)
 
     @property
     def _base_data_type(self) -> str:

--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -359,7 +359,7 @@ def _subset_treeneuron(x, subset, keep_disc_cn, prevent_fragments):
     return x
 
 
-def submesh(mesh, *, faces_index=None, vertex_index=None):
+def submesh(mesh, *, faces_index=None, vertex_index=None, return_map=False):
     """Re-imlementation of trimesh.submesh that is faster for our use case.
 
     Notably we:
@@ -382,6 +382,9 @@ def submesh(mesh, *, faces_index=None, vertex_index=None):
                     Indices of faces to keep.
     vertex_index :  array-like
                     Indices of vertices to keep.
+    return_map :    bool, optional
+                    If True, will return a mapping of old to new vertex and
+                    face indices.
 
     Returns
     -------
@@ -389,6 +392,14 @@ def submesh(mesh, *, faces_index=None, vertex_index=None):
                 Vertices of submesh.
     faces :     np.ndarray
                 Faces of submesh.
+    vert_map :  np.ndarray
+                Only returned if `return_map` is True. Mapping of old vertex indices
+                to new vertex indices. Vertices that are not in the submesh have a
+                value of -1.
+    face_map :  np.ndarray
+                Only returned if `return_map` is True. Mapping of old face indices
+                to new face indices. Faces that are not in the submesh have a value
+                of -1.
 
     """
     if faces_index is None and vertex_index is None:
@@ -439,4 +450,14 @@ def submesh(mesh, *, faces_index=None, vertex_index=None):
     # (making a copy to allow `mask` to be garbage collected)
     faces = mask[faces].copy()
 
-    return vertices, faces
+    if not return_map:
+        return vertices, faces
+    else:
+        face_map = np.full(len(original_faces), -1, dtype=np.int32)
+        face_map[faces_index] = np.arange(len(faces_index))
+        vert_map = np.full(len(original_vertices), -1, dtype=np.int32)
+        vert_map[unique] = np.arange(len(unique))
+        return vertices, faces, vert_map, face_map
+
+
+

--- a/navis/morpho/subset.py
+++ b/navis/morpho/subset.py
@@ -308,13 +308,9 @@ def _subset_treeneuron(x, subset, keep_disc_cn, prevent_fragments):
         axis=1,
     )
 
-    # Make sure any new roots or leafs are properly typed
-    # We won't produce new slabs but roots and leaves might change
-    x.nodes.loc[x.nodes.parent_id < 0, "type"] = "root"
-    x.nodes.loc[
-        (~x.nodes.node_id.isin(x.nodes.parent_id.values) & (x.nodes.parent_id >= 0)),
-        "type",
-    ] = "end"
+    # Make sure nodes are correctly classified (need to do this because we're not actually clearing
+    # the temporary attributes)
+    graph.classify_nodes(x, inplace=True)
 
     # Filter connectors
     if not keep_disc_cn and x.has_connectors:


### PR DESCRIPTION
This PR adds an interface for masking neurons for analyses/processing:

- [ ] masking/unmasking for:
   - [x] skeleton
   - [x] dotprops
   - [x] meshes
   - [ ] voxels (not sure this is strictly necessary)
- [x] `NeuronMask` context manager 
- [x] update API documentation
- [ ] add tutorials 
- [ ] a generalizable solution for destructive operations (e.g. prune twigs)

The interface currently looks like this:

```python
n = navis.example_neurons(1, kind='skeleton')

# Generate a mask
n.mask(mask=n.nodes.y > 25000)
# ... do your thing here 
n.unmask(reset=True)

# Alternatively:
with navis.NeuronMask(n, mask=n.nodes.y > 25000):
   # ... do your thing here
```

A few additional notes:
- `mask` can be a boolean array, a neuron property (e.g. a column in the node table), or a function that takes a neuron and returns one of the first two. 
- in my head, the `NeuronMask` context manager is the primary interface but people can also mess around with `.mask()` + `.unmask()` if they need more control. Neurons also have a `.apply_mask()` method that makes the mask permanent. 
- under-the-hood we copy the data when masking a neuron but that can be switched off if a user know the data won't be modified

### Modifying masked neurons

By default, unmasking will reset the neuron to its original state. Users can use e.g. `.unmask(reset=False)` or `NeuronMask(..., reset=False)` to instead re-combine the masked and unmasked data. That works well for non-destructive operations such as e.g. smoothing or downsampling where the boundary vertices/nodes are not modified:

```python
n = navis.example_neurons(1, kind='skeleton')
# Label axon and dendrite
navis.split_axon_dendrite(n, label_only=True)
# Downsample only the axon 
with navis.NeuronMask(n, mask=lambda x: x.nodes.compartment == 'axon', reset_neurons=False):
   navis.downsample_neuron(n, 5, inplace=True)
```
<img width="752" alt="Screenshot 2024-10-24 at 13 18 57" src="https://github.com/user-attachments/assets/59625e4d-4c02-40f2-b9f2-b1654c3819d7">

Destructive operations (e.g. `navis.prune_twigs`) are more tricky and I think we may end up having to adjust those functions to deal with masked neurons as special cases. To give you an example: skeletonization of neurons often leaves ugly spikes where the soma is. These could be removed by masking the neuron to within a given radius of the soma and removing all twigs below a given threshold. However, with the current implementation the actual neurites coming off the soma would also look awfully like twigs and might incorrectly get pruned off - which in turn will break the connectivity of the skeleton. Perfectly solvable problem but I'm still thinking about a generalizable approach that would minimize maintenance burden.

Comments/thoughts, @ceesem @bdpedigo?


