### PR TITLE
Issue 174

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -29,8 +29,7 @@ jobs:
         sudo apt-get update -y -qq
         sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
           libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-          libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 graphviz graphviz-dev \
-          mesa-vulkan-drivers
+          libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 graphviz
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -45,6 +44,11 @@ jobs:
     #   if: ${{ matrix.igraph == 'igraph' }}
     - name: Report dependency versions
       run: pip freeze -r requirements.txt
+    - uses: moguri/setup-blender@v1
+      with:
+          blender-version: '4.2.4'
+    - name: Install Blender
+      run: blender --version
     - name: Test
       uses: coactions/setup-xvfb@v1
       with:

--- a/navis/meshes/b3d.py
+++ b/navis/meshes/b3d.py
@@ -37,6 +37,16 @@ def simplify_mesh_blender(x, F, inplace=False):
     simp
                 Simplified mesh object.
 
+    Examples
+    --------
+    >>> import navis
+    >>> n = navis.example_neurons(1, kind="mesh")
+    >>> n_sm = simplify_mesh_blender(n,
+    ...         F=0.2,
+    ...         inplace=False)
+    >>> n.n_vertices > n_sm.n_vertices
+    True
+
     """
     if not tm.interfaces.blender.exists:
         raise ModuleNotFoundError('No Blender 3D unavailable (executable not found).')

--- a/navis/meshes/templates/blender_decimate.py.template
+++ b/navis/meshes/templates/blender_decimate.py.template
@@ -5,21 +5,29 @@ import os
 if __name__ == '__main__':
     # clear scene of default box
     bpy.ops.wm.read_homefile()
-    try:
-        bpy.ops.object.mode_set(mode='OBJECT')
-    except BaseException:
-        pass
-    bpy.ops.object.select_all(action='SELECT')
-    bpy.ops.object.delete(use_global=True)
+    if bpy.app.version > (3, 2, 0):
+        objs = [bpy.context.scene.objects['Camera'], bpy.context.scene.objects['Cube'], bpy.context.scene.objects['Light']]
+        with bpy.context.temp_override(selected_objects=objs):
+            bpy.ops.object.delete()
+    else:
+        try:
+            bpy.ops.object.mode_set(mode='OBJECT')
+        except BaseException:
+            pass
+        bpy.ops.object.select_all(action='SELECT')
+        bpy.ops.object.delete(use_global=True)
 
     # get temporary files from templated locations
     mesh_pre = $MESH_PRE
     mesh_post = os.path.abspath(r'$MESH_POST')
 
     for filename in mesh_pre:  # use data.objects instead of context.scene.objects
-        bpy.ops.import_mesh.stl(filepath=os.path.abspath(filename))
-
+        if bpy.app.version > (4, 0, 0):
+            bpy.ops.wm.stl_import(filepath=os.path.abspath(filename))
+        else:
+            bpy.ops.import_mesh.stl(filepath=os.path.abspath(filename))
     mesh = bpy.data.objects[0]
+
     # Make sure mesh is the active object
     try:
         # earlier than blender <2.8
@@ -29,6 +37,7 @@ if __name__ == '__main__':
         bpy.context.view_layer.objects.active = mesh
 
     # add decimate modifier
+
     mod = mesh.modifiers.new('decimate', 'DECIMATE')
     mod.decimate_type = 'COLLAPSE'
     mod.ratio = $RATIO
@@ -36,6 +45,9 @@ if __name__ == '__main__':
 
     bpy.ops.object.modifier_apply(modifier=mod.name)
 
-    bpy.ops.export_mesh.stl(
-        filepath=mesh_post,
-        use_mesh_modifiers=True)
+    if bpy.app.version > (4, 0, 0):
+        bpy.ops.wm.stl_export(filepath=mesh_post, apply_modifiers=True)
+    else:
+        bpy.ops.export_mesh.stl(
+            filepath=mesh_post,
+            use_mesh_modifiers=True)


### PR DESCRIPTION
potential fix for issue with blender 4.3:
- changing `bpy.ops.import_mesh.stl()` to `bpy.ops.wm.stl_import()` created context error which was fixed by:
- `bpy.ops.object.select_all` → `bpy.context.scene.objects`

Deprecation warning for context was added in blender-3.2. The `wm.stl_import` should work at least since blender-4.0.