### PR TITLE
Fix numpy doctest

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -58,4 +58,5 @@ jobs:
         with:
           run: |
             export NAVIS_HEADLESS=TRUE
+            export NAVIS_TEST_ENV=TRUE
             pytest --verbose

--- a/navis/config.py
+++ b/navis/config.py
@@ -59,6 +59,12 @@ def get_logger(name: str):
         return logging.getLogger(name)
     return logger
 
+# Set up numpy number representation, see NEP51
+# Once numpy<=2 is dropped from requirements, the doctest comparissons
+# should become `np.float64(1.074)` instead of `1.074`
+if os.environ.get('NAVIS_TEST_ENV', '').lower() == 'true':
+    import numpy as np
+    np.set_printoptions(legacy="1.25")
 
 # Default settings for progress bars
 pbar_hide = False

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -30,12 +30,6 @@ from .. import config, graph, sampling, core, utils
 # Set up logging
 logger = config.get_logger(__name__)
 
-# Set up numpy number representation, see NEP51
-# Once numpy<=2 is dropped from requirements, the doctest comparissons
-# should become `np.float64(1.074)` instead of `1.074`
-if int(np.version.version.split('.')[0])>=2:
-    np.set_printoptions(legacy="1.25")
-
 __all__ = sorted(
     [
         "strahler_index",
@@ -1327,7 +1321,12 @@ def tortuosity(
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.float64(1.074)` instead of `1.074`)
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+        np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> # Calculate tortuosity as-is
     >>> T = navis.tortuosity(n)

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -15,6 +15,7 @@
 """This module contains functions to analyse and manipulate neuron morphology."""
 
 import math
+import os
 import itertools
 import scipy
 import warnings
@@ -29,6 +30,12 @@ from .. import config, graph, sampling, core, utils
 
 # Set up logging
 logger = config.get_logger(__name__)
+
+# Set up numpy number representation, see NEP51
+# Once numpy<=2 is dropped from requirements, the doctest comparissons
+# should become `np.float64(1.074)` instead of `1.074`
+if os.environ.get('NAVIS_TEST_ENV', '').lower() == 'true':
+    np.set_printoptions(legacy="1.25")
 
 __all__ = sorted(
     [
@@ -1321,12 +1328,7 @@ def tortuosity(
 
     Examples
     --------
-    (Set up numpy number representation within the test, see NEP51.
-    Once numpy<=2 is dropped from requirements, the doctest comparissons
-    should become `np.float64(1.074)` instead of `1.074`)
     >>> import navis
-    >>> if int(np.version.version.split('.')[0])>=2:
-        np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> # Calculate tortuosity as-is
     >>> T = navis.tortuosity(n)

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -15,7 +15,6 @@
 """This module contains functions to analyse and manipulate neuron morphology."""
 
 import math
-import os
 import itertools
 import scipy
 import warnings
@@ -31,11 +30,6 @@ from .. import config, graph, sampling, core, utils
 # Set up logging
 logger = config.get_logger(__name__)
 
-# Set up numpy number representation, see NEP51
-# Once numpy<=2 is dropped from requirements, the doctest comparissons
-# should become `np.float64(1.074)` instead of `1.074`
-if os.environ.get('NAVIS_TEST_ENV', '').lower() == 'true':
-    np.set_printoptions(legacy="1.25")
 
 __all__ = sorted(
     [

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -30,6 +30,12 @@ from .. import config, graph, sampling, core, utils
 # Set up logging
 logger = config.get_logger(__name__)
 
+# Set up numpy number representation, see NEP51
+# Once numpy<=2 is dropped from requirements, the doctest comparissons
+# should become `np.float64(1.074)` instead of `1.074`
+if int(np.version.version.split('.')[0])>=2:
+    np.set_printoptions(legacy="1.25")
+
 __all__ = sorted(
     [
         "strahler_index",

--- a/navis/plotting/plot_utils.py
+++ b/navis/plotting/plot_utils.py
@@ -190,7 +190,7 @@ def make_tube(segments, radii=1.0, tube_points=8, use_normals=True):
     faces :         np.ndarray
 
     """
-    vertices = np.empty((0, 3), dtype=np.float_)
+    vertices = np.empty((0, 3), dtype=np.float64)
     indices = np.empty((0, 3), dtype=np.uint32)
 
     if not isinstance(radii, Iterable):
@@ -219,7 +219,7 @@ def make_tube(segments, radii=1.0, tube_points=8, use_normals=True):
         # Vertices for each point on the circle
         verts = np.repeat(points, tube_points, axis=0)
 
-        v = np.arange(tube_points, dtype=np.float_) / tube_points * 2 * np.pi
+        v = np.arange(tube_points, dtype=np.float64) / tube_points * 2 * np.pi
 
         all_cx = (
             radius

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ doctest_optionflags = IGNORE_EXCEPTION_DETAIL NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-modules
 env =
     NAVIS_HEADLESS=TRUE
+    NAVIS_TEST_ENV=TRUE


### PR DESCRIPTION
This PR potentially improves the numpy>=2.0 compatibility
- I replaced two references to `np.float_` as a dtype (and the minimum numpy version 1.16 seems to support both)
- NEP51 changes the representation of scalars (e.g. `np.float64(1.074)`, which fails the doctest when compared to `1.074`). While numpy<2.0 is still an accepted dependency, I change the representation back to python scalars to pass the tests.

This problem came up in #175, but is a separate issue, hence the separate PR.