### PR TITLE
Fix numpy doctest local

### DIFF
--- a/navis/core/base.py
+++ b/navis/core/base.py
@@ -613,7 +613,7 @@ class BaseNeuron(UnitObject):
         should become `np.float32(266476.88)` instead of `266476.8`)
         >>> import navis
         >>> if int(np.version.version.split('.')[0])>=2:
-                np.set_printoptions(legacy="1.25")
+        ...     np.set_printoptions(legacy="1.25")
         >>> n = navis.example_neurons(1)
         >>> n.units
         <Quantity(8, 'nanometer')>

--- a/navis/core/base.py
+++ b/navis/core/base.py
@@ -608,7 +608,12 @@ class BaseNeuron(UnitObject):
 
         Examples
         --------
+        (Set up numpy number representation within the test, see NEP51.
+        Once numpy<=2 is dropped from requirements, the doctest comparissons
+        should become `np.float32(266476.88)` instead of `266476.8`)
         >>> import navis
+        >>> if int(np.version.version.split('.')[0])>=2:
+                np.set_printoptions(legacy="1.25")
         >>> n = navis.example_neurons(1)
         >>> n.units
         <Quantity(8, 'nanometer')>

--- a/navis/core/skeleton.py
+++ b/navis/core/skeleton.py
@@ -1427,7 +1427,7 @@ class TreeNeuron(BaseNeuron):
         should become `np.int32(1124)` instead of `1124`)
         >>> import navis
         >>> if int(np.version.version.split('.')[0])>=2:
-                np.set_printoptions(legacy="1.25")
+        ...     np.set_printoptions(legacy="1.25")
         >>> n = navis.example_neurons(1)
         >>> id, dist = n.snap([0, 0, 0])
         >>> id

--- a/navis/core/skeleton.py
+++ b/navis/core/skeleton.py
@@ -1422,7 +1422,12 @@ class TreeNeuron(BaseNeuron):
 
         Examples
         --------
+        (Set up numpy number representation within the test, see NEP51.
+        Once numpy<=2 is dropped from requirements, the doctest comparissons
+        should become `np.int32(1124)` instead of `1124`)
         >>> import navis
+        >>> if int(np.version.version.split('.')[0])>=2:
+                np.set_printoptions(legacy="1.25")
         >>> n = navis.example_neurons(1)
         >>> id, dist = n.snap([0, 0, 0])
         >>> id

--- a/navis/graph/graph_utils.py
+++ b/navis/graph/graph_utils.py
@@ -1078,7 +1078,12 @@ def find_main_branchpoint(
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.int32(110)` instead of `110`)
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> navis.find_main_branchpoint(n, reroot_soma=True)
     110

--- a/navis/graph/graph_utils.py
+++ b/navis/graph/graph_utils.py
@@ -1083,7 +1083,7 @@ def find_main_branchpoint(
     should become `np.int32(110)` instead of `110`)
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> navis.find_main_branchpoint(n, reroot_soma=True)
     110

--- a/navis/intersection/intersect.py
+++ b/navis/intersection/intersect.py
@@ -205,7 +205,7 @@ def in_volume(x: Union['core.NeuronObject', Sequence, pd.DataFrame],
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> lh = navis.example_volume('LH')
     >>> n_lh = navis.in_volume(n, lh, inplace=False)

--- a/navis/intersection/intersect.py
+++ b/navis/intersection/intersect.py
@@ -198,7 +198,14 @@ def in_volume(x: Union['core.NeuronObject', Sequence, pd.DataFrame],
     --------
     Prune neuron to volume
 
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `array([False, False, False, ..., False, False, False], shape=(4465,))` 
+    instead of `array([False, False, False, ..., False, False, False])`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> lh = navis.example_volume('LH')
     >>> n_lh = navis.in_volume(n, lh, inplace=False)

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -30,12 +30,6 @@ from .. import config, graph, sampling, core, utils
 # Set up logging
 logger = config.get_logger(__name__)
 
-# Set up numpy number representation, see NEP51
-# Once numpy<=2 is dropped from requirements, the doctest comparissons
-# should become `np.float64(1.074)` instead of `1.074`
-if int(np.version.version.split('.')[0])>=2:
-    np.set_printoptions(legacy="1.25")
-
 __all__ = sorted(
     [
         "strahler_index",
@@ -1327,7 +1321,12 @@ def tortuosity(
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.float64(1.074)` instead of `1.074`)
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+        np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> # Calculate tortuosity as-is
     >>> T = navis.tortuosity(n)

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -147,7 +147,13 @@ def strahler_index(
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.int16(6)` instead of `91234`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2, kind='skeleton')
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.strahler_index(n)
@@ -550,7 +556,13 @@ def arbor_segregation_index(x: "core.NeuronObject") -> "core.NeuronObject":
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.float64(0.277)` instead of `0.277`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.arbor_segregation_index(n)
@@ -699,7 +711,13 @@ def bending_flow(x: "core.NeuronObject") -> "core.NeuronObject":
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.int64(785645)` instead of `785645`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.bending_flow(n)
@@ -969,7 +987,13 @@ def synapse_flow_centrality(
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.int64(786969)` instead of `786969`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.synapse_flow_centrality(n)
@@ -1174,7 +1198,13 @@ def flow_centrality(x: "core.NeuronObject") -> "core.NeuronObject":
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.int64(91234)` instead of `91234`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.flow_centrality(n)
@@ -1326,7 +1356,7 @@ def tortuosity(
     should become `np.float64(1.074)` instead of `1.074`)
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-        np.set_printoptions(legacy="1.25")
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> # Calculate tortuosity as-is
     >>> T = navis.tortuosity(n)
@@ -1635,7 +1665,13 @@ def betweeness_centrality(
 
     Examples
     --------
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.int64(436866)` instead of `436866`)
+
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2, kind='skeleton')
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.betweeness_centrality(n)

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -153,7 +153,7 @@ def strahler_index(
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2, kind='skeleton')
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.strahler_index(n)
@@ -562,7 +562,7 @@ def arbor_segregation_index(x: "core.NeuronObject") -> "core.NeuronObject":
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.arbor_segregation_index(n)
@@ -717,7 +717,7 @@ def bending_flow(x: "core.NeuronObject") -> "core.NeuronObject":
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.bending_flow(n)
@@ -993,7 +993,7 @@ def synapse_flow_centrality(
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.synapse_flow_centrality(n)
@@ -1204,7 +1204,7 @@ def flow_centrality(x: "core.NeuronObject") -> "core.NeuronObject":
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2)
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.flow_centrality(n)
@@ -1356,7 +1356,7 @@ def tortuosity(
     should become `np.float64(1.074)` instead of `1.074`)
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(1)
     >>> # Calculate tortuosity as-is
     >>> T = navis.tortuosity(n)
@@ -1671,7 +1671,7 @@ def betweeness_centrality(
 
     >>> import navis
     >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
+    ...     np.set_printoptions(legacy="1.25")
     >>> n = navis.example_neurons(2, kind='skeleton')
     >>> n.reroot(n.soma, inplace=True)
     >>> _ = navis.betweeness_centrality(n)

--- a/navis/morpho/mmetrics.py
+++ b/navis/morpho/mmetrics.py
@@ -30,6 +30,12 @@ from .. import config, graph, sampling, core, utils
 # Set up logging
 logger = config.get_logger(__name__)
 
+# Set up numpy number representation, see NEP51
+# Once numpy<=2 is dropped from requirements, the doctest comparissons
+# should become `np.float64(1.074)` instead of `1.074`
+if int(np.version.version.split('.')[0])>=2:
+    np.set_printoptions(legacy="1.25")
+
 __all__ = sorted(
     [
         "strahler_index",

--- a/navis/nbl/utils.py
+++ b/navis/nbl/utils.py
@@ -199,7 +199,12 @@ def update_scores(queries, targets, scores_ex, nblast_func, **kwargs):
 
     Mostly for testing but also illustrates the principle:
 
+    (Set up numpy number representation within the test, see NEP51.
+    Once numpy<=2 is dropped from requirements, the doctest comparissons
+    should become `np.True_` instead of `True`)
     >>> import navis
+    >>> if int(np.version.version.split('.')[0])>=2:
+            np.set_printoptions(legacy="1.25")
     >>> import numpy as np
     >>> nl = navis.example_neurons(n=5)
     >>> dp = navis.make_dotprops(nl, k=5) / 125

--- a/navis/nbl/utils.py
+++ b/navis/nbl/utils.py
@@ -203,9 +203,9 @@ def update_scores(queries, targets, scores_ex, nblast_func, **kwargs):
     Once numpy<=2 is dropped from requirements, the doctest comparissons
     should become `np.True_` instead of `True`)
     >>> import navis
-    >>> if int(np.version.version.split('.')[0])>=2:
-            np.set_printoptions(legacy="1.25")
     >>> import numpy as np
+    >>> if int(np.version.version.split('.')[0])>=2:
+    ...     np.set_printoptions(legacy="1.25")
     >>> nl = navis.example_neurons(n=5)
     >>> dp = navis.make_dotprops(nl, k=5) / 125
     >>> # Full NBLAST

--- a/navis/plotting/plot_utils.py
+++ b/navis/plotting/plot_utils.py
@@ -190,7 +190,7 @@ def make_tube(segments, radii=1.0, tube_points=8, use_normals=True):
     faces :         np.ndarray
 
     """
-    vertices = np.empty((0, 3), dtype=np.float_)
+    vertices = np.empty((0, 3), dtype=np.float64)
     indices = np.empty((0, 3), dtype=np.uint32)
 
     if not isinstance(radii, Iterable):
@@ -219,7 +219,7 @@ def make_tube(segments, radii=1.0, tube_points=8, use_normals=True):
         # Vertices for each point on the circle
         verts = np.repeat(points, tube_points, axis=0)
 
-        v = np.arange(tube_points, dtype=np.float_) / tube_points * 2 * np.pi
+        v = np.arange(tube_points, dtype=np.float64) / tube_points * 2 * np.pi
 
         all_cx = (
             radius


### PR DESCRIPTION
This PR potentially improves the numpy>=2.0 compatibility

- I replaced two references to np.float_ as a dtype (and the minimum numpy version 1.16 seems to support both)
- NEP51 changes the representation of scalars (e.g. np.float64(1.074), which fails the doctest when compared to 1.074). While numpy<2.0 is still an accepted dependency, I change the representation back to python scalars to pass the tests.
- As opposed to #176, this PR configures the number representation within each test. The comment for each test shows the potential expected results, once numpy>=2.0 is the minimum requirement.

This problem came up in #175 and is an alternative solution to #176.