### PR TITLE
Match behavior between vanilla and fastcore generation of skeleton segments

### DIFF
--- a/navis/graph/graph_utils.py
+++ b/navis/graph/graph_utils.py
@@ -150,14 +150,17 @@ def _generate_segments(
     lengths = [d[s[0]] - d[s[-1]] for s in sequences]
     sequences = [x for _, x in sorted(zip(lengths, sequences), reverse=True)]
 
+    # Turn into list of arrays
+    sequences = [np.array(s) for s in sequences]
+
     # Isolated nodes would not be included in the sequences(because they are treated
     # as roots, not leafs. Let's add them manually here.
     for node in nx.isolates(x.graph):
-        sequences.append([node])
+        sequences.append(np.array([node]))
         lengths.append(0)
 
     if return_lengths:
-        return sequences, sorted(lengths, reverse=True)
+        return sequences, np.array(sorted(lengths, reverse=True))
     else:
         return sequences
 


### PR DESCRIPTION
Addresses issue flagged in #179:

Previously, the vanilla implementation of `_generate_segments` would ignore isolated nodes. That's because it walks from each leaf to the correspond root, and isolated nodes are treated as roots rather than a root that is also a leaf. The implementation of this in `navis-fastcore` already returns segments containing only a single node.

With this PR, the vanilla implementation of `_generate_segments` will:
- return single node segments
- return a list of arrays (previously a list of lists)