### PR TITLE
Prevent overflows 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ flybrains  #extra: flybrains
 
 cloud-volume>=5.2.0  #extra: cloudvolume
 
-navis-fastcore>=0.0.8  #extra: fastcore
+navis-fastcore>=0.1.0  #extra: fastcore
 
 plotly>=4.9  #extra: plotly
 


### PR DESCRIPTION
This PR adds safeguards against overflows for functions that (potentially) increase the number of nodes in a neuron:

- [x] `navis.resample_skeleton`
- [ ] `navis.stitch_skeletons`
- [ ] `navis.insert_nodes`
- [ ] `navis.resample_along_axis`
- [ ] `navis.combine_neurons` 

Edit 03/12:
On closer inspection, the only function where overflows are an actual problem is `navis.resample_skeleton` and that only because it tries to force the same datatypes as the input neuron. All other functions that add new nodes let pandas free rein which means data is typically upcast. 

With the current fix `navis.resample_skeleton` will try to downcast to the input neuron's data types but check node IDs for potential overflows - if there are, it will downcast to the smallest possible integer dtype. This could be a model for the other functions but I'm also worried that this may make the code more brittle (e.g. some edge case we hadn't considered). For most users it won't make much difference whether data is e.g. int64 instead of int32, and power users will be able to cast data types as needed.

On a side note: it should be fairly straight forward to make `fastcore` deal with 16bit node IDs.

Edit 03/13:

With the new version `0.1.0`, `fastcore` now supports 16bit node IDs.