### PR TITLE
Connector fix

### DIFF
--- a/navis/plotting/colors.py
+++ b/navis/plotting/colors.py
@@ -30,7 +30,7 @@ from .. import core, config, utils, morpho
 
 __all__ = ['generate_colors', 'prepare_connector_cmap', 'prepare_colormap',
            'eval_color', 'hex_to_rgb', 'vary_colors', 'vertex_colors',
-           'color_to_int']
+           'color_to_int', 'set_alpha']
 
 logger = config.get_logger(__name__)
 
@@ -698,3 +698,58 @@ def vary_colors(color: AnyColor,
     color[:, :3] = color[:, :3] + variance[:, :3]
 
     return np.clip(color, 0, 1)
+
+
+def set_alpha(color: Union[np.ndarray, list, tuple], alpha: float):
+    """Set alpha channel for given color.
+
+    Will add alpha channel if not present.
+
+    Parameters
+    ----------
+    color : array-like, shape (..., 3) or (..., 4)
+            Single RGB or RGBA color or array of colors.
+    alpha : float
+            Alpha value to set, in range [0, 1].
+
+    """
+    if isinstance(color, np.ndarray):
+        color = color.copy()
+        if color.ndim == 2:
+            if color.shape[1] == 3:
+                alpha_channel = np.full((color.shape[0], 1), alpha)
+                color = np.hstack((color, alpha_channel))
+            elif color.shape[1] == 4:
+                color[:, 3] = alpha
+            else:
+                raise ValueError("Color array must have shape (..., 3) or (..., 4).")
+        elif color.ndim == 1:
+            if color.shape[0] == 3:
+                color = np.append(color, alpha)
+            elif color.shape[0] == 4:
+                color[3] = alpha
+            else:
+                raise ValueError("Color array must have shape (..., 3) or (..., 4).")
+        else:
+            raise ValueError("Color array must have shape (..., 3) or (..., 4).")
+    elif isinstance(color, list):
+        color = color.copy()
+        if len(color) == 3:
+            color.append(alpha)
+        elif len(color) == 4:
+            color[3] = alpha
+        else:
+            raise ValueError("Color list must have length 3 or 4.")
+    elif isinstance(color, tuple):
+        if len(color) == 3:
+            color = list(color) + [alpha]
+        elif len(color) == 4:
+            color = list(color)
+            color[3] = alpha
+        else:
+            raise ValueError("Color tuple must have length 3 or 4.")
+        color = tuple(color)
+    else:
+        raise TypeError("Color must be a numpy array, list, or tuple.")
+
+    return color

--- a/navis/plotting/dd.py
+++ b/navis/plotting/dd.py
@@ -922,6 +922,7 @@ def _plot_connectors(neuron, color, ax, settings):
                 edgecolor="none",
                 s=settings.cn_size if settings.cn_size else cn_layout["size"],
                 zorder=1000,
+                zorder=settings.cn_zorder if settings.cn_zorder is not None else 1000,
             )
             ax.get_children()[-1].set_gid(f"CN_{neuron.id}")
     elif settings.method in ["3d", "3d_complex"]:
@@ -934,6 +935,7 @@ def _plot_connectors(neuron, color, ax, settings):
             s=settings.cn_size if settings.cn_size else cn_layout["size"],
             depthshade=cn_layout.get("depthshade", False),
             zorder=0,
+            zorder=settings.cn_zorder if settings.cn_zorder is not None else 0,  # not sure this does anything in 3d
             edgecolor="none",
         )
         ax.get_children()[-1].set_gid(f"CN_{neuron.id}")
@@ -1369,7 +1371,7 @@ def _plot_volume(volume, color, ax, settings):
             ax.add_collection(pc)
 
         if settings.volume_outlines in (True, "both"):
-            verts = volume.to_2d(view=settings.view, alpha=0.001)
+            verts = volume.to_2d(view=settings.view, alpha=settings.get("volume_outlines_alpha", 0.001))
             vpatch = mpatches.Polygon(
                 verts,
                 closed=True,

--- a/navis/plotting/dd.py
+++ b/navis/plotting/dd.py
@@ -922,7 +922,7 @@ def _plot_connectors(neuron, color, ax, settings):
                 color=cn_layout[c]["color"],
                 edgecolor="none",
                 s=settings.cn_size if settings.cn_size else cn_layout["size"],
-                zorder=1000,
+                alpha=settings.get('cn_alpha', None),
                 zorder=settings.cn_zorder if settings.cn_zorder is not None else 1000,
             )
             ax.get_children()[-1].set_gid(f"CN_{neuron.id}")
@@ -935,7 +935,7 @@ def _plot_connectors(neuron, color, ax, settings):
             color=c,
             s=settings.cn_size if settings.cn_size else cn_layout["size"],
             depthshade=cn_layout.get("depthshade", False),
-            zorder=0,
+            alpha=settings.get('cn_alpha', None),
             zorder=settings.cn_zorder if settings.cn_zorder is not None else 0,  # not sure this does anything in 3d
             edgecolor="none",
         )

--- a/navis/plotting/dd.py
+++ b/navis/plotting/dd.py
@@ -901,8 +901,7 @@ def _plot_connectors(neuron, color, ax, settings):
             if not isinstance(inner_dict, dict):
                 continue
             inner_dict["color"] = color
-
-    if settings.cn_colors:
+    elif settings.cn_colors:
         if isinstance(settings.cn_colors, dict):
             cn_layout.update(settings.cn_colors)
         else:

--- a/navis/plotting/dd.py
+++ b/navis/plotting/dd.py
@@ -171,33 +171,34 @@ def plot2d(
                         a string or a list is provided, it will be used to filter the
                         `type` column in the connectors table.
 
+    connectors :        bool | "presynapses" | "postsynapses" | str | list, default=True
+
+                        Plot connectors. This can either be `True` (plot all
+                        connectors), `"presynapses"` (only presynaptic connectors)
+                        or `"postsynapses"` (only postsynaptic connectors). If
+                        a string or a list is provided, it will be used to filter the
+                        `type` column in the connectors table.
+
+                        Use these parameters to adjust the way connectors are plotted:
+
+                          - `cn_colors` (str | tuple | dict | "neuron" ) overrides
+                            the default connector (e.g. synpase) colors:
+                              - single color as str (e.g. `'red'`) or rgb tuple
+                                (e.g. `(1, 0, 0)`)
+                              - dict mapping the connectors tables `type` column to
+                                a color (e.g. `{"pre": (1, 0, 0)}`)
+                              - with "neuron", connectors will receive the same color
+                                as their neuron
+                          - `cn_layout` (dict): Layout of the connectors. See
+                            `navis.config.default_connector_colors` for options.
+                          - `cn_size` (float): Size of the connectors.
+                          - `cn_alpha` (float): Transparency of the connectors.
+                          - `cn_mesh_colors` (bool): Whether to color the connectors
+                            by the neuron's color.
+
     connectors_only :   boolean, default=False
 
                         Plot only connectors, not the neuron.
-
-    cn_size :           int | float, default = 1
-
-                        Size of connectors.
-
-    cn_layout :         dict, default={}
-
-                        Defines default settings (color, style) for connectors.
-                        See `navis.config.default_connector_colors` for the
-                        default layout.
-
-    cn_colors :         str | tuple | dict | "neuron"
-
-                        Overrides the default connector (e.g. synpase) colors:
-                            - single color as str (e.g. `'red'`) or rgb tuple
-                            (e.g. `(1, 0, 0)`)
-                            - dict mapping the connectors tables `type` column to
-                            a color (e.g. `{"pre": (1, 0, 0)}`)
-                            - with "neuron", connectors will receive the same color
-                            as their neuron
-
-    cn_mesh_colors :    bool, default=False
-
-                        If True, will use the neuron's color for its connectors.
 
     scatter_kws :       dict, default={}
 

--- a/navis/plotting/k3d/k3d_objects.py
+++ b/navis/plotting/k3d/k3d_objects.py
@@ -218,6 +218,7 @@ def neuron2k3d(x, colormap, settings):
                                 if settings.cn_size
                                 else cn_lay["size"] * 50,
                                 color=c,
+                                opacity=settings.get('cn_alpha', 1),
                             )
                         )
                 elif cn_lay["display"] == "lines":

--- a/navis/plotting/settings.py
+++ b/navis/plotting/settings.py
@@ -136,12 +136,14 @@ class Matplotlib2dSettings(BasePlottingSettings):
     orthogonal: bool = True
     scalebar: Union[int, float, str, pint.Quantity] = False
     volume_outlines: bool = False
+    volume_outlines_alpha: float = 0.001
     rasterize: bool = False
     view: Tuple[str, str] = ("x", "y")
     figsize: Optional[Tuple[float, float]] = None
     ax: Optional[mpl.axes.Axes] = None
     mesh_shade: bool = False
     non_view_axes3d: Literal["hide", "show", "fade"] = "hide"
+    cn_zorder: Optional[int] = None
 
     depth_coloring: bool = False
     depth_scale: bool = True

--- a/navis/plotting/vispy/visuals.py
+++ b/navis/plotting/vispy/visuals.py
@@ -25,7 +25,7 @@ import numpy as np
 import matplotlib.colors as mcl
 
 from ... import core, config, utils, conversion
-from ..colors import prepare_colormap, vertex_colors, eval_color
+from ..colors import prepare_colormap, vertex_colors, eval_color, set_alpha
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -347,6 +347,7 @@ def connectors2vispy(neuron, neuron_color, object_id, settings):
             con = scene.visuals.Markers(
                 spherical=cn_lay.get("spherical", True),
                 scaling=cn_lay.get("scale", False),
+                alpha=settings.get("cn_alpha", 1),
             )
 
             con.set_data(
@@ -365,6 +366,10 @@ def connectors2vispy(neuron, neuron_color, object_id, settings):
             )
 
             segments = [item for sublist in zip(pos, tn_coords) for item in sublist]
+
+            # If we have an connector alpha value, we need to set color accordingly
+            if settings.get("cn_alpha", None) is not None:
+                color = set_alpha(color, settings.cn_alpha)
 
             con = scene.visuals.Line(
                 pos=np.array(segments),

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ jupyter_rfb>=0.4.1
 #extra: octarine-default
 
 octarine3d[all]>=0.2.3
-octarine-navis-plugin>=0.1.2
+octarine-navis-plugin>=0.1.3
 
 #extra: meshes
 


### PR DESCRIPTION
This PR fixes a number of issues with connector plotting:

- `plot3d`: `cn_alpha`, `cn_colors` and `cn_mesh_colors` now work across all backens
- `plot2d` now respects `cn_alpha`
- improved docstrings 